### PR TITLE
Add new apps to the catalog

### DIFF
--- a/pages/repositories/airbyte.md
+++ b/pages/repositories/airbyte.md
@@ -1,59 +1,26 @@
----
-title: Airbyte
-description: Open-source ELT platform.
----
+
+# Airbyte
 
 ## Description
-
-Plural will install Airbyte in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one
-CLI command.
+Plural will install Airbyte in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
-
-We currently support this repository on the following infrastructure providers:
+We currently support Airbyte for the following providers:
 
 {% tabs %}
-
-{% tab title="AWS" %}
-```shell
-plural bundle install airbyte airbyte-aws
-```
-{% /tab %}
-{% tab title="GCP" %}
-```shell
-plural bundle install airbyte airbyte-gcp
-```
-{% /tab %}
-{% tab title="Azure" %}
-```shell
-plural bundle install airbyte airbyte-azure
-```
-{% /tab %}
-{% tab title="KinD" %}
-```shell
-plural bundle install airbyte airbyte-kind
-```
-{% /tab %}
-
-{% /tabs %}
+{% tab title="AWS" %} plural bundle install airbyte airbyte-aws {% endtab %} {% tab title="AZURE" %} plural bundle install airbyte airbyte-azure {% endtab %} {% tab title="GCP" %} plural bundle install airbyte airbyte-gcp {% endtab %} {% tab title="KIND" %} plural bundle install airbyte airbyte-kind {% endtab %}
+{% endtabs %}
 
 ## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
-`vpc_name`: We need an isolated VPC to launch your resources in, so we create one for you. Stick with `plural` for
-most cases. This is a cluster-level setting that we only ask for once. Once you've set this up, you won't need to do it again.
 
-`wal_bucket`: Plural uses Postgres as the backing database for cluster information. We need to store the WAL logs
-somewhere to backup and restore from. This is a cluster-level setting that we only ask for once. Once you've set this up, you won't need to do it again unless you destroy
-all existing applications.
 
-`airbyteBucket`: We want to store your Airbyte logs in a S3-like bucket for easy access. Use the default by pressing [Enter] unless it's
-been used before. This configuration step is **not idempotent**, if you have to redo configuration
-for any reason, you'll need to create a new bucket. Alternatively you can directly edit the `context.yaml` file to use
-the existing bucket that you create in this step.
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
-`hostname`: This will be where your Airbyte instance is hosted. Generally, use `airbyte.$YOUR_ORG_NAME.onplural.sh`.
+`airbyteBucket`: Arbitrary bucket name to store airbyte logs in
 
-`privateHostname`: This will be the hostname under which the Airbyte API will be accessible. As a suggestion, use `airbytedev.$YOUR_ORG_NAME.onplural.sh`.
+`hostname`: the fully qualified domain name your airbyte instance will be available at
 
-`Enable plural OIDC`: Enabling Plural OIDC means that you won't need to worry about authenticating into this app if you're logged into Plural. We highly recommend this
-as long as you don't have any specific security requirements.
+`privateHostname`: a private dns name to securely access the airbyte api from
+    

--- a/pages/repositories/airbyte.md
+++ b/pages/repositories/airbyte.md
@@ -2,16 +2,32 @@
 # Airbyte
 
 ## Description
+
 Plural will install Airbyte in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Airbyte for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install airbyte airbyte-aws {% endtab %} {% tab title="AZURE" %} plural bundle install airbyte airbyte-azure {% endtab %} {% tab title="GCP" %} plural bundle install airbyte airbyte-gcp {% endtab %} {% tab title="KIND" %} plural bundle install airbyte airbyte-kind {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install airbyte airbyte-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install airbyte airbyte-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install airbyte airbyte-gcp
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install airbyte airbyte-kind
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -23,4 +39,5 @@ We currently support Airbyte for the following providers:
 `hostname`: the fully qualified domain name your airbyte instance will be available at
 
 `privateHostname`: a private dns name to securely access the airbyte api from
-    
+
+

--- a/pages/repositories/airflow.md
+++ b/pages/repositories/airflow.md
@@ -1,83 +1,40 @@
----
-title: Airflow
-description: A DAG-based, dependency-aware job scheduler.
----
+
+# Airflow
 
 ## Description
-
-Plural will install Airflow in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one
-CLI command.
+Plural will install Airflow in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
-
-We currently support this repository on the following infrastructure providers:
+We currently support Airflow for the following providers:
 
 {% tabs %}
-
-{% tab title="AWS" %}
-```shell
-plural bundle install airflow airflow-aws
-```
-{% /tab %}
-{% tab title="GCP" %}
-```shell
-plural bundle install airflow airflow-gcp
-```
-{% /tab %}
-{% tab title="Azure" %}
-```shell
-plural bundle install airflow airflow-azure
-```
-{% /tab %}
-{% tab title="KinD" %}
-```shell
-plural bundle install airflow airflow-kind
-```
-{% /tab %}
-
-{% /tabs %}
+{% tab title="AWS" %} plural bundle install airflow airflow-aws {% endtab %} {% tab title="AZURE" %} plural bundle install airflow airflow-azure {% endtab %} {% tab title="GCP" %} plural bundle install airflow airflow-gcp {% endtab %}
+{% endtabs %}
 
 ## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
-`vpc_name`: We need an isolated VPC to launch your resources in, so we create one for you. Stick with `plural` for
-most cases. This is a cluster-level setting that we only ask for once. Once you've set this up, you won't need to do it again.
 
-`wal_bucket`: Plural uses Postgres as the backing database for cluster information. We need to store the WAL logs
-somewhere to backup and restore from. This is a cluster-level setting that we only ask for once. Once you've set this up, you won't need to do it again unless you destroy
-all existing applications.
 
-`airflowBucket`: We want to store your Airflow logs in a S3-like bucket for easy access. Use the default by pressing [Enter] unless it's 
-been used before. This configuration step is **not idempotent**, if you have to redo configuration
-for any reason, you'll need to create a new bucket. Alternatively you can directly edit the `context.yaml` file to use
-the existing bucket that you create in this step.
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
-`hostname`: This will be where your Airflow instance is hosted. Generally, use `airflow.$YOUR_ORG_NAME.onplural.sh`.
+`airflowBucket`: Arbitrary bucket name to store the logs in
 
-`dagRepo`: We'll need a preexisting GitHub repository to store the DAGs that you create and use in Airflow. Either create
-one now or use an existing DAG repository. Then grab the SSH URL from the `Code` tab on the repo to use here.
+`hostname`: Fully Qualified Domain Name to use for your airflow installation, eg airflow.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
 
-`branchName`: If you have an existing DAG repository, you may want to sync your existing dags into and from a specific 
-branch. This will be the branch that Plural stays up to date with, so use `main` unless you want to prevent direct changes
-to the repository.
+`dagRepo`: Git Repo url for storing dags, should be a ssh url like git@github.com:pluralsh/airflow-dags.git
 
-`adminUsername`: Use your naming preference for admin accounts. No need to reinvent the wheel, `admin` is fine too.
+`branchName`: The branch to sync from
 
-`adminFirst`: Use your relevant operator's first name or just use `admin`.
+`adminUsername`: The airflow username for the admin
 
-`adminLast`: Use your relevant operator's last name or just use `admin`.
+`adminFirst`: The first name for the admin
 
-`adminEmail`: Use your relevant admin operator's email address. This will the email used to manage the Airflow instance.
+`adminLast`: The last name for the admin
 
-`private_key`: This makes sure that your admin account has Read/Write access to the DAG repo. We recommend you stick with the default, unless you have
-compliance reasons for this file not existing here.
+`adminEmail`: The email for the admin
 
-`public_key`: Similar to `private_key`, this makes sure that your admin account has Read/Write access to the DAG repo. We recommend you stick with the default, unless you have
-compliance reasons for this file not existing here.
+`private_key`: path to the private key to use for git authentication
 
-`Enable plural OIDC`: Enabling Plural OIDC means that you won't need to worry about authenticating into this app if you're logged into Plural. We highly recommend this
-as long as you don't have any specific security requirements.
-
-## Auth Configuration
-
-`git_user`: Plural will perform Git operations on your behalf to manage your config repository. Just use your GitHub
-username here, unless you have a dedicated user for Ops.
+`public_key`: path to the public key to use for git authentication
+    

--- a/pages/repositories/airflow.md
+++ b/pages/repositories/airflow.md
@@ -2,16 +2,29 @@
 # Airflow
 
 ## Description
+
 Plural will install Airflow in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Airflow for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install airflow airflow-aws {% endtab %} {% tab title="AZURE" %} plural bundle install airflow airflow-azure {% endtab %} {% tab title="GCP" %} plural bundle install airflow airflow-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install airflow airflow-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install airflow airflow-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install airflow airflow-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -37,4 +50,5 @@ We currently support Airflow for the following providers:
 `private_key`: path to the private key to use for git authentication
 
 `public_key`: path to the public key to use for git authentication
-    
+
+

--- a/pages/repositories/argo-cd.md
+++ b/pages/repositories/argo-cd.md
@@ -2,16 +2,29 @@
 # Argo-cd
 
 ## Description
+
 Plural will install Argo-cd in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Argo-cd for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install argo-cd argo-cd-aws {% endtab %} {% tab title="AZURE" %} plural bundle install argo-cd argo-cd-azure {% endtab %} {% tab title="GCP" %} plural bundle install argo-cd argo-cd-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install argo-cd argo-cd-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install argo-cd argo-cd-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install argo-cd argo-cd-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -35,4 +48,5 @@ We currently support Argo-cd for the following providers:
 `privateRepoURL`: URL of the private repository
 
 `enableImageUpdater`: Enable the Argo CD Image Updater
-    
+
+

--- a/pages/repositories/argo-cd.md
+++ b/pages/repositories/argo-cd.md
@@ -1,0 +1,38 @@
+
+# Argo-cd
+
+## Description
+Plural will install Argo-cd in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Argo-cd for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install argo-cd argo-cd-aws {% endtab %} {% tab title="AZURE" %} plural bundle install argo-cd argo-cd-azure {% endtab %} {% tab title="GCP" %} plural bundle install argo-cd argo-cd-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+`hostname`: FQDN to use for your Argo CD installation
+
+`adminGroup`: OIDC group that should receive admin permissions
+
+`credentialTemplateURL`: Domain for which to configure private repository credentials
+
+`credentialUsername`: Username to access private repositories
+
+`credentialPassword`: Password or Personal Access Token to access private repositories
+
+`privateRepoName`: Name for the private repository to add
+
+`privateRepoURL`: URL of the private repository
+
+`enableImageUpdater`: Enable the Argo CD Image Updater
+    

--- a/pages/repositories/argo-workflows.md
+++ b/pages/repositories/argo-workflows.md
@@ -1,0 +1,24 @@
+
+# Argo-workflows
+
+## Description
+Plural will install Argo-workflows in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Argo-workflows for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install argo-workflows argo-workflows-aws {% endtab %} {% tab title="AZURE" %} plural bundle install argo-workflows argo-workflows-azure {% endtab %} {% tab title="GCP" %} plural bundle install argo-workflows argo-workflows-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`workflowBucket`: bucket to workflow artifacts in
+
+`hostname`: FQDN to use for your Argo Workflows installation
+
+`adminEmail`: email address for the admin user
+
+`adminGroup`: specify a user group to grant admin rights to
+    

--- a/pages/repositories/argo-workflows.md
+++ b/pages/repositories/argo-workflows.md
@@ -2,16 +2,29 @@
 # Argo-workflows
 
 ## Description
+
 Plural will install Argo-workflows in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Argo-workflows for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install argo-workflows argo-workflows-aws {% endtab %} {% tab title="AZURE" %} plural bundle install argo-workflows argo-workflows-azure {% endtab %} {% tab title="GCP" %} plural bundle install argo-workflows argo-workflows-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install argo-workflows argo-workflows-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install argo-workflows argo-workflows-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install argo-workflows argo-workflows-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `workflowBucket`: bucket to workflow artifacts in
@@ -21,4 +34,5 @@ We currently support Argo-workflows for the following providers:
 `adminEmail`: email address for the admin user
 
 `adminGroup`: specify a user group to grant admin rights to
-    
+
+

--- a/pages/repositories/chatwoot.md
+++ b/pages/repositories/chatwoot.md
@@ -1,0 +1,28 @@
+
+# Chatwoot
+
+## Description
+Plural will install Chatwoot in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Chatwoot for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install chatwoot chatwoot-aws {% endtab %} {% tab title="AZURE" %} plural bundle install chatwoot chatwoot-azure {% endtab %} {% tab title="GCP" %} plural bundle install chatwoot chatwoot-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+`chatwootBucket`: bucket to store chatwoot files in
+
+`hostname`: FQDN to use for your chatwoot installation
+    

--- a/pages/repositories/chatwoot.md
+++ b/pages/repositories/chatwoot.md
@@ -2,16 +2,29 @@
 # Chatwoot
 
 ## Description
+
 Plural will install Chatwoot in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Chatwoot for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install chatwoot chatwoot-aws {% endtab %} {% tab title="AZURE" %} plural bundle install chatwoot chatwoot-azure {% endtab %} {% tab title="GCP" %} plural bundle install chatwoot chatwoot-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install chatwoot chatwoot-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install chatwoot chatwoot-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install chatwoot chatwoot-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -25,4 +38,5 @@ We currently support Chatwoot for the following providers:
 `chatwootBucket`: bucket to store chatwoot files in
 
 `hostname`: FQDN to use for your chatwoot installation
-    
+
+

--- a/pages/repositories/console.md
+++ b/pages/repositories/console.md
@@ -2,16 +2,35 @@
 # Console
 
 ## Description
+
 Plural will install Console in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Console for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install console console-aws {% endtab %} {% tab title="AZURE" %} plural bundle install console console-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install console console-equinix {% endtab %} {% tab title="GCP" %} plural bundle install console console-gcp {% endtab %} {% tab title="KIND" %} plural bundle install console console-kind {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install console console-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install console console-azure
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install console console-equinix
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install console console-gcp
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install console console-kind
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -37,4 +56,5 @@ We currently support Console for the following providers:
 `public_key`: path to the public key to use for git authentication
 
 `passphrase`: passphrase to use for encrypted private keys (leave empty if not applicable)
-    
+
+

--- a/pages/repositories/console.md
+++ b/pages/repositories/console.md
@@ -1,75 +1,40 @@
----
-title: Plural Console
-description: A Plural admin console for monitoring and ops.
----
+
+# Console
 
 ## Description
-
-Plural will install Console in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one
-CLI command.
+Plural will install Console in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
-
-We currently support this repository on the following infrastructure providers: 
+We currently support Console for the following providers:
 
 {% tabs %}
-
-{% tab title="AWS" %}
-```shell
-plural bundle install console console-aws
-```
-{% /tab %}
-{% tab title="GCP" %}
-```shell
-plural bundle install console console-gcp
-```
-{% /tab %}
-{% tab title="Azure" %}
-```shell
-plural bundle install console console-azure
-```
-{% /tab %}
-{% tab title="Equinix" %}
-```shell
-plural bundle install console console-equinix
-```
-{% /tab %}
-{% tab title="KinD" %}
-```shell
-plural bundle install console console-kind
-```
-{% /tab %}
-
-{% /tabs %}
+{% tab title="AWS" %} plural bundle install console console-aws {% endtab %} {% tab title="AZURE" %} plural bundle install console console-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install console console-equinix {% endtab %} {% tab title="GCP" %} plural bundle install console console-gcp {% endtab %} {% tab title="KIND" %} plural bundle install console console-kind {% endtab %}
+{% endtabs %}
 
 ## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
-`vpc_name`: We need an isolated VPC to launch your resources in, so we create one for you. Stick with `plural` for
-most cases. This is a cluster-level setting that we only ask for once. Once you've set this up, you won't need to do it again.
 
-`wal_bucket`: Plural uses Postgres as the backing database for cluster information. We need to store the WAL logs
-somewhere to backup and restore from. This is a cluster-level setting that we only ask for once. Once you've set this up, you won't need to do it again unless you destroy
-all existing applications.
 
-`console_dns`: This will be where your console is hosted. Generally, use `console.$YOUR_ORG_NAME.onplural.sh`.
 
-`Enable plural OIDC`: Enabling Plural OIDC means that you won't need to worry about authenticating into this app if you're logged into Plural. We highly recommend this
-as long as you don't have any specific security requirements.
 
-## Auth Configuration
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
-`git_user`: Plural will perform Git operations on your behalf to manage your config repository. Just use your GitHub
-username here, unless you have a dedicated user for Ops.
+`console_dns`: Fully Qualified Domain Name for the console dashboard, eg console.topleveldomain.com if topleveldomain.com is the hostname you inputed above.
 
-`git_email`: Use the email tied to the account associated with `git_user`
+`git_user`: git username for console to use in git operations, eg your github username
 
-`admin_name`: Use your naming preference for admin accounts. No need to reinvent the wheel, `admin` is fine too.
+`git_email`: email for git operations by console
 
-`private_key`: This makes sure that your admin account has Read/Write access to the config repo. We recommend you stick with the default, unless you have 
-compliance reasons for this file not existing here.
+`admin_name`: name for the initial admin user
 
-`public_key`: Similar to `private_key`, this makes sure that your admin account has Read/Write access to the DAG repo. We recommend you stick with the default, unless you have
-compliance reasons for this file not existing here.
+`repo_url`: the url to the remote git repo
 
-`passphrase`: If you have encrypted your SSH key with a passphrase for extra security, you'll need to enter it here in order
-for Plural to use it for Git operations.
+`access_token`: github/gitlab access token to use for http git authentication
+
+`private_key`: path to the private key to use for git authentication
+
+`public_key`: path to the public key to use for git authentication
+
+`passphrase`: passphrase to use for encrypted private keys (leave empty if not applicable)
+    

--- a/pages/repositories/crossplane.md
+++ b/pages/repositories/crossplane.md
@@ -2,17 +2,25 @@
 # Crossplane
 
 ## Description
+
 Plural will install Crossplane in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Crossplane for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install crossplane crossplane-aws {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install crossplane crossplane-aws
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/crossplane.md
+++ b/pages/repositories/crossplane.md
@@ -1,0 +1,18 @@
+
+# Crossplane
+
+## Description
+Plural will install Crossplane in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Crossplane for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install crossplane crossplane-aws {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/dagster.md
+++ b/pages/repositories/dagster.md
@@ -1,0 +1,24 @@
+
+# Dagster
+
+## Description
+Plural will install Dagster in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Dagster for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install dagster dagster-aws {% endtab %} {% tab title="AZURE" %} plural bundle install dagster dagster-azure {% endtab %} {% tab title="GCP" %} plural bundle install dagster dagster-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`dagsterBucket`: s3 bucket for storing dagster logs
+
+`hostname`: fqdn on which to deploy your dagster instance
+    

--- a/pages/repositories/dagster.md
+++ b/pages/repositories/dagster.md
@@ -2,16 +2,29 @@
 # Dagster
 
 ## Description
+
 Plural will install Dagster in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Dagster for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install dagster dagster-aws {% endtab %} {% tab title="AZURE" %} plural bundle install dagster dagster-azure {% endtab %} {% tab title="GCP" %} plural bundle install dagster dagster-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install dagster dagster-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install dagster dagster-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install dagster dagster-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -21,4 +34,5 @@ We currently support Dagster for the following providers:
 `dagsterBucket`: s3 bucket for storing dagster logs
 
 `hostname`: fqdn on which to deploy your dagster instance
-    
+
+

--- a/pages/repositories/datahub.md
+++ b/pages/repositories/datahub.md
@@ -2,16 +2,29 @@
 # Datahub
 
 ## Description
+
 Plural will install Datahub in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Datahub for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install datahub datahub-aws {% endtab %} {% tab title="AZURE" %} plural bundle install datahub datahub-azure {% endtab %} {% tab title="GCP" %} plural bundle install datahub datahub-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install datahub datahub-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install datahub datahub-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install datahub datahub-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -23,4 +36,5 @@ We currently support Datahub for the following providers:
 `wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
 `hostname`: domain on which you'd like to host datahub's page
-    
+
+

--- a/pages/repositories/datahub.md
+++ b/pages/repositories/datahub.md
@@ -1,0 +1,26 @@
+
+# Datahub
+
+## Description
+Plural will install Datahub in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Datahub for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install datahub datahub-aws {% endtab %} {% tab title="AZURE" %} plural bundle install datahub datahub-azure {% endtab %} {% tab title="GCP" %} plural bundle install datahub datahub-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`hostname`: hostname for your kibana instance
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`hostname`: domain on which you'd like to host datahub's page
+    

--- a/pages/repositories/etcd.md
+++ b/pages/repositories/etcd.md
@@ -2,17 +2,37 @@
 # Etcd
 
 ## Description
+
 Plural will install Etcd in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Etcd for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install etcd etcd-aws {% endtab %} {% tab title="AZURE" %} plural bundle install etcd etcd-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install etcd etcd-equinix {% endtab %} {% tab title="GCP" %} plural bundle install etcd etcd-gcp {% endtab %} {% tab title="KIND" %} plural bundle install etcd etcd-kind {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install etcd etcd-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install etcd etcd-azure
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install etcd etcd-equinix
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install etcd etcd-gcp
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install etcd etcd-kind
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/etcd.md
+++ b/pages/repositories/etcd.md
@@ -1,0 +1,18 @@
+
+# Etcd
+
+## Description
+Plural will install Etcd in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Etcd for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install etcd etcd-aws {% endtab %} {% tab title="AZURE" %} plural bundle install etcd etcd-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install etcd etcd-equinix {% endtab %} {% tab title="GCP" %} plural bundle install etcd etcd-gcp {% endtab %} {% tab title="KIND" %} plural bundle install etcd etcd-kind {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/filecoin.md
+++ b/pages/repositories/filecoin.md
@@ -2,17 +2,25 @@
 # Filecoin
 
 ## Description
+
 Plural will install Filecoin in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Filecoin for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install filecoin filecoin-aws {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install filecoin filecoin-aws
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/filecoin.md
+++ b/pages/repositories/filecoin.md
@@ -1,0 +1,18 @@
+
+# Filecoin
+
+## Description
+Plural will install Filecoin in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Filecoin for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install filecoin filecoin-aws {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/ghost.md
+++ b/pages/repositories/ghost.md
@@ -1,0 +1,30 @@
+
+# Ghost
+
+## Description
+Plural will install Ghost in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Ghost for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install ghost ghost-aws {% endtab %} {% tab title="AZURE" %} plural bundle install ghost ghost-azure {% endtab %} {% tab title="GCP" %} plural bundle install ghost ghost-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`backup_bucket`: bucket to store mysql backups in
+
+`hostname`: FQDN to use for your accessing the mysql orchestrator
+
+`ghostUser`: username for your initial ghost user account
+
+`ghostEmail`: email address for the initial ghost user
+
+`ghostDomain`: fully qualified domain name for the ghost blog instance
+
+`blogTitle`: title for your ghost-powered blog
+    

--- a/pages/repositories/ghost.md
+++ b/pages/repositories/ghost.md
@@ -2,16 +2,29 @@
 # Ghost
 
 ## Description
+
 Plural will install Ghost in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Ghost for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install ghost ghost-aws {% endtab %} {% tab title="AZURE" %} plural bundle install ghost ghost-azure {% endtab %} {% tab title="GCP" %} plural bundle install ghost ghost-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install ghost ghost-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install ghost ghost-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install ghost ghost-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -27,4 +40,5 @@ We currently support Ghost for the following providers:
 `ghostDomain`: fully qualified domain name for the ghost blog instance
 
 `blogTitle`: title for your ghost-powered blog
-    
+
+

--- a/pages/repositories/gitlab.md
+++ b/pages/repositories/gitlab.md
@@ -2,16 +2,26 @@
 # Gitlab
 
 ## Description
+
 Plural will install Gitlab in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Gitlab for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install gitlab aws-gitlab {% endtab %} {% tab title="GCP" %} plural bundle install gitlab gcp-gitlab {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install gitlab aws-gitlab
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install gitlab gcp-gitlab
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -35,4 +45,5 @@ We currently support Gitlab for the following providers:
 `runnerCacheBucket`: bucket name for gitlab runner cache
 
 `terraformBucket`: bucket name for gitlab managed terraform state
-    
+
+

--- a/pages/repositories/gitlab.md
+++ b/pages/repositories/gitlab.md
@@ -1,0 +1,38 @@
+
+# Gitlab
+
+## Description
+Plural will install Gitlab in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Gitlab for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install gitlab aws-gitlab {% endtab %} {% tab title="GCP" %} plural bundle install gitlab gcp-gitlab {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`registryBucket`: bucket name for gitlab registry
+
+`artifactsBucket`: bucket name for gitlab artifacts
+
+`uploadsBucket`: bucket name for gitlab uploads
+
+`packagesBucket`: bucket name for gitlab packages
+
+`backupsBucket`: bucket name for gitlab backups
+
+`backupsTmpBucket`: bucket name for gitlab tmp backups
+
+`lfsBucket`: bucket name for git large file storage
+
+`runnerCacheBucket`: bucket name for gitlab runner cache
+
+`terraformBucket`: bucket name for gitlab managed terraform state
+    

--- a/pages/repositories/grafana.md
+++ b/pages/repositories/grafana.md
@@ -1,0 +1,20 @@
+
+# Grafana
+
+## Description
+Plural will install Grafana in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Grafana for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install grafana aws-grafana {% endtab %} {% tab title="AZURE" %} plural bundle install grafana azure-grafana {% endtab %} {% tab title="EQUINIX" %} plural bundle install grafana equinix-grafana {% endtab %} {% tab title="GCP" %} plural bundle install grafana gcp-grafana {% endtab %} {% tab title="KIND" %} plural bundle install grafana kind-grafana {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`hostname`: FQDN to use for your grafana installation
+    

--- a/pages/repositories/grafana.md
+++ b/pages/repositories/grafana.md
@@ -2,19 +2,39 @@
 # Grafana
 
 ## Description
+
 Plural will install Grafana in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Grafana for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install grafana aws-grafana {% endtab %} {% tab title="AZURE" %} plural bundle install grafana azure-grafana {% endtab %} {% tab title="EQUINIX" %} plural bundle install grafana equinix-grafana {% endtab %} {% tab title="GCP" %} plural bundle install grafana gcp-grafana {% endtab %} {% tab title="KIND" %} plural bundle install grafana kind-grafana {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install grafana aws-grafana
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install grafana azure-grafana
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install grafana equinix-grafana
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install grafana gcp-grafana
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install grafana kind-grafana
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
 
 `hostname`: FQDN to use for your grafana installation
-    
+
+

--- a/pages/repositories/growthbook.md
+++ b/pages/repositories/growthbook.md
@@ -2,16 +2,29 @@
 # Growthbook
 
 ## Description
+
 Plural will install Growthbook in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Growthbook for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install growthbook growthbook-aws {% endtab %} {% tab title="AZURE" %} plural bundle install growthbook growthbook-azure {% endtab %} {% tab title="GCP" %} plural bundle install growthbook growthbook-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install growthbook growthbook-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install growthbook growthbook-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install growthbook growthbook-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -23,4 +36,5 @@ We currently support Growthbook for the following providers:
 `apiHostname`: the domain name for the growthbook api (should be different from hostname)
 
 `growthbookBucket`: bucket for your growthbook instance
-    
+
+

--- a/pages/repositories/growthbook.md
+++ b/pages/repositories/growthbook.md
@@ -1,0 +1,26 @@
+
+# Growthbook
+
+## Description
+Plural will install Growthbook in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Growthbook for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install growthbook growthbook-aws {% endtab %} {% tab title="AZURE" %} plural bundle install growthbook growthbook-azure {% endtab %} {% tab title="GCP" %} plural bundle install growthbook growthbook-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+`hostname`: the domain name for your growthbook instance
+
+`apiHostname`: the domain name for the growthbook api (should be different from hostname)
+
+`growthbookBucket`: bucket for your growthbook instance
+    

--- a/pages/repositories/hasura.md
+++ b/pages/repositories/hasura.md
@@ -2,16 +2,29 @@
 # Hasura
 
 ## Description
+
 Plural will install Hasura in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Hasura for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install hasura hasura-aws {% endtab %} {% tab title="AZURE" %} plural bundle install hasura hasura-azure {% endtab %} {% tab title="GCP" %} plural bundle install hasura hasura-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install hasura hasura-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install hasura hasura-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install hasura hasura-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -19,4 +32,5 @@ We currently support Hasura for the following providers:
 `wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
 `hostname`: Fully Qualified Domain Name to use for your hasura installation, eg hasura.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
-    
+
+

--- a/pages/repositories/hasura.md
+++ b/pages/repositories/hasura.md
@@ -1,0 +1,22 @@
+
+# Hasura
+
+## Description
+Plural will install Hasura in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Hasura for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install hasura hasura-aws {% endtab %} {% tab title="AZURE" %} plural bundle install hasura hasura-azure {% endtab %} {% tab title="GCP" %} plural bundle install hasura hasura-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`hostname`: Fully Qualified Domain Name to use for your hasura installation, eg hasura.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
+    

--- a/pages/repositories/influx.md
+++ b/pages/repositories/influx.md
@@ -1,0 +1,30 @@
+
+# Influx
+
+## Description
+Plural will install Influx in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Influx for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install influx influx-aws {% endtab %} {% tab title="AZURE" %} plural bundle install influx influx-azure {% endtab %} {% tab title="GCP" %} plural bundle install influx influx-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`enableChronograf`: whether to deploy the chronograf web ui
+
+`chronografHostname`: Fully Qualified Domain Name for the chronograf web ui
+
+`enableKapacitor`: whether to deploy kapacitor alerting
+
+`enableTelegraf`: whether to deploy telegraf metrics collection
+
+`databaseName`: name for the initial bootstrapped database
+
+`influxdbHostname`: external dns name for your influxdb instance (leave empty if you don't want ingress)
+    

--- a/pages/repositories/influx.md
+++ b/pages/repositories/influx.md
@@ -2,16 +2,29 @@
 # Influx
 
 ## Description
+
 Plural will install Influx in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Influx for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install influx influx-aws {% endtab %} {% tab title="AZURE" %} plural bundle install influx influx-azure {% endtab %} {% tab title="GCP" %} plural bundle install influx influx-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install influx influx-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install influx influx-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install influx influx-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -27,4 +40,5 @@ We currently support Influx for the following providers:
 `databaseName`: name for the initial bootstrapped database
 
 `influxdbHostname`: external dns name for your influxdb instance (leave empty if you don't want ingress)
-    
+
+

--- a/pages/repositories/ingress-nginx.md
+++ b/pages/repositories/ingress-nginx.md
@@ -2,17 +2,37 @@
 # Ingress-nginx
 
 ## Description
+
 Plural will install Ingress-nginx in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Ingress-nginx for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install ingress-nginx ingress-nginx-aws {% endtab %} {% tab title="AZURE" %} plural bundle install ingress-nginx ingress-nginx-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install ingress-nginx ingress-nginx-equinix {% endtab %} {% tab title="GCP" %} plural bundle install ingress-nginx ingress-nginx-gcp {% endtab %} {% tab title="KIND" %} plural bundle install ingress-nginx ingress-nginx-kind {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install ingress-nginx ingress-nginx-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install ingress-nginx ingress-nginx-azure
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install ingress-nginx ingress-nginx-equinix
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install ingress-nginx ingress-nginx-gcp
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install ingress-nginx ingress-nginx-kind
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/ingress-nginx.md
+++ b/pages/repositories/ingress-nginx.md
@@ -1,0 +1,18 @@
+
+# Ingress-nginx
+
+## Description
+Plural will install Ingress-nginx in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Ingress-nginx for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install ingress-nginx ingress-nginx-aws {% endtab %} {% tab title="AZURE" %} plural bundle install ingress-nginx ingress-nginx-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install ingress-nginx ingress-nginx-equinix {% endtab %} {% tab title="GCP" %} plural bundle install ingress-nginx ingress-nginx-gcp {% endtab %} {% tab title="KIND" %} plural bundle install ingress-nginx ingress-nginx-kind {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/istio.md
+++ b/pages/repositories/istio.md
@@ -2,16 +2,29 @@
 # Istio
 
 ## Description
+
 Plural will install Istio in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Istio for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install istio istio-aws {% endtab %} {% tab title="AZURE" %} plural bundle install istio istio-azure {% endtab %} {% tab title="GCP" %} plural bundle install istio istio-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install istio istio-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install istio istio-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install istio istio-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -25,4 +38,5 @@ We currently support Istio for the following providers:
 `tempoBucket`: Arbitrary bucket name to store the traces in, eg plural-tempo-traces
 
 `kialiHostname`: FQDN to use for the Kiali installation
-    
+
+

--- a/pages/repositories/istio.md
+++ b/pages/repositories/istio.md
@@ -1,0 +1,28 @@
+
+# Istio
+
+## Description
+Plural will install Istio in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Istio for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install istio istio-aws {% endtab %} {% tab title="AZURE" %} plural bundle install istio istio-azure {% endtab %} {% tab title="GCP" %} plural bundle install istio istio-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+`tempoBucket`: Arbitrary bucket name to store the traces in, eg plural-tempo-traces
+
+`kialiHostname`: FQDN to use for the Kiali installation
+    

--- a/pages/repositories/jitsu.md
+++ b/pages/repositories/jitsu.md
@@ -1,0 +1,26 @@
+
+# Jitsu
+
+## Description
+Plural will install Jitsu in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Jitsu for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install jitsu jitsu-aws {% endtab %} {% tab title="AZURE" %} plural bundle install jitsu jitsu-azure {% endtab %} {% tab title="GCP" %} plural bundle install jitsu jitsu-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+`hostname`: domain on which you'd like to host jitsu's configuration page
+
+`apiHostname`: domain on which you'd like to host jitsu's api
+    

--- a/pages/repositories/jitsu.md
+++ b/pages/repositories/jitsu.md
@@ -2,16 +2,29 @@
 # Jitsu
 
 ## Description
+
 Plural will install Jitsu in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Jitsu for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install jitsu jitsu-aws {% endtab %} {% tab title="AZURE" %} plural bundle install jitsu jitsu-azure {% endtab %} {% tab title="GCP" %} plural bundle install jitsu jitsu-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install jitsu jitsu-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install jitsu jitsu-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install jitsu jitsu-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -23,4 +36,5 @@ We currently support Jitsu for the following providers:
 `hostname`: domain on which you'd like to host jitsu's configuration page
 
 `apiHostname`: domain on which you'd like to host jitsu's api
-    
+
+

--- a/pages/repositories/kafka.md
+++ b/pages/repositories/kafka.md
@@ -2,17 +2,31 @@
 # Kafka
 
 ## Description
+
 Plural will install Kafka in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Kafka for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install kafka aws-kafka {% endtab %} {% tab title="AZURE" %} plural bundle install kafka azure-kafka {% endtab %} {% tab title="GCP" %} plural bundle install kafka gcp-kafka {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install kafka aws-kafka
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install kafka azure-kafka
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install kafka gcp-kafka
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/kafka.md
+++ b/pages/repositories/kafka.md
@@ -1,0 +1,18 @@
+
+# Kafka
+
+## Description
+Plural will install Kafka in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Kafka for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install kafka aws-kafka {% endtab %} {% tab title="AZURE" %} plural bundle install kafka azure-kafka {% endtab %} {% tab title="GCP" %} plural bundle install kafka gcp-kafka {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/knative.md
+++ b/pages/repositories/knative.md
@@ -2,16 +2,29 @@
 # Knative
 
 ## Description
+
 Plural will install Knative in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Knative for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install knative knative-aws {% endtab %} {% tab title="GCP" %} plural bundle install knative knative-gcp {% endtab %} {% tab title="AWS" %} plural bundle install knative knative-operator-aws {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install knative knative-aws
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install knative knative-gcp
+{% /tab %}
+{% tab title="AWS" %}
+plural bundle install knative knative-operator-aws
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -27,4 +40,5 @@ We currently support Knative for the following providers:
 `kialiHostname`: FQDN to use for the Kiali installation
 
 
-    
+
+

--- a/pages/repositories/knative.md
+++ b/pages/repositories/knative.md
@@ -1,0 +1,30 @@
+
+# Knative
+
+## Description
+Plural will install Knative in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Knative for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install knative knative-aws {% endtab %} {% tab title="GCP" %} plural bundle install knative knative-gcp {% endtab %} {% tab title="AWS" %} plural bundle install knative knative-operator-aws {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+`tempoBucket`: Arbitrary bucket name to store the traces in, eg plural-tempo-traces
+
+`kialiHostname`: FQDN to use for the Kiali installation
+
+
+    

--- a/pages/repositories/kserve.md
+++ b/pages/repositories/kserve.md
@@ -1,0 +1,32 @@
+
+# Kserve
+
+## Description
+Plural will install Kserve in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Kserve for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install kserve kserve-aws {% endtab %} {% tab title="AZURE" %} plural bundle install kserve kserve-azure {% endtab %} {% tab title="GCP" %} plural bundle install kserve kserve-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+`tempoBucket`: Arbitrary bucket name to store the traces in, eg plural-tempo-traces
+
+`kialiHostname`: FQDN to use for the Kiali installation
+
+
+
+
+    

--- a/pages/repositories/kserve.md
+++ b/pages/repositories/kserve.md
@@ -2,16 +2,29 @@
 # Kserve
 
 ## Description
+
 Plural will install Kserve in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Kserve for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install kserve kserve-aws {% endtab %} {% tab title="AZURE" %} plural bundle install kserve kserve-azure {% endtab %} {% tab title="GCP" %} plural bundle install kserve kserve-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install kserve kserve-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install kserve kserve-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install kserve kserve-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -29,4 +42,5 @@ We currently support Kserve for the following providers:
 
 
 
-    
+
+

--- a/pages/repositories/kubecost.md
+++ b/pages/repositories/kubecost.md
@@ -2,16 +2,29 @@
 # Kubecost
 
 ## Description
+
 Plural will install Kubecost in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Kubecost for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install kubecost kubecost-aws {% endtab %} {% tab title="AZURE" %} plural bundle install kubecost kubecost-azure {% endtab %} {% tab title="GCP" %} plural bundle install kubecost kubecost-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install kubecost kubecost-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install kubecost kubecost-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install kubecost kubecost-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -21,4 +34,5 @@ We currently support Kubecost for the following providers:
 `hostname`: FQDN to use for your grafana installation
 
 `hostname`: FQDN to use for your KubeCost installation
-    
+
+

--- a/pages/repositories/kubecost.md
+++ b/pages/repositories/kubecost.md
@@ -1,0 +1,24 @@
+
+# Kubecost
+
+## Description
+Plural will install Kubecost in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Kubecost for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install kubecost kubecost-aws {% endtab %} {% tab title="AZURE" %} plural bundle install kubecost kubecost-azure {% endtab %} {% tab title="GCP" %} plural bundle install kubecost kubecost-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+`hostname`: FQDN to use for your grafana installation
+
+`hostname`: FQDN to use for your KubeCost installation
+    

--- a/pages/repositories/kubeflow.md
+++ b/pages/repositories/kubeflow.md
@@ -2,16 +2,26 @@
 # Kubeflow
 
 ## Description
+
 Plural will install Kubeflow in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Kubeflow for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install kubeflow kubeflow-aws {% endtab %} {% tab title="GCP" %} plural bundle install kubeflow kubeflow-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install kubeflow kubeflow-aws
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install kubeflow kubeflow-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -39,4 +49,5 @@ We currently support Kubeflow for the following providers:
 `pipelines_bucket`: bucket to store the pipeline artifacts and logs in
 
 `hostname`: FQDN to use for your Kubeflow installation
-    
+
+

--- a/pages/repositories/kubeflow.md
+++ b/pages/repositories/kubeflow.md
@@ -1,0 +1,42 @@
+
+# Kubeflow
+
+## Description
+Plural will install Kubeflow in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Kubeflow for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install kubeflow kubeflow-aws {% endtab %} {% tab title="GCP" %} plural bundle install kubeflow kubeflow-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+
+
+`backup_bucket`: bucket to store mysql backups in
+
+`hostname`: FQDN to use for your accessing the mysql orchestrator
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+`tempoBucket`: Arbitrary bucket name to store the traces in, eg plural-tempo-traces
+
+`kialiHostname`: FQDN to use for the Kiali installation
+
+
+
+
+
+`pipelines_bucket`: bucket to store the pipeline artifacts and logs in
+
+`hostname`: FQDN to use for your Kubeflow installation
+    

--- a/pages/repositories/kubescape.md
+++ b/pages/repositories/kubescape.md
@@ -1,0 +1,18 @@
+
+# Kubescape
+
+## Description
+Plural will install Kubescape in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Kubescape for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install kubescape kubescape-aws {% endtab %} {% tab title="AZURE" %} plural bundle install kubescape kubescape-azure {% endtab %} {% tab title="GCP" %} plural bundle install kubescape kubescape-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`accountGuid`: Unique identifier connecting results to the Kubescape Cloud account. To learn more go here https://hub.armosec.io/docs/kubescape-cloud-account#account-id
+    

--- a/pages/repositories/kubescape.md
+++ b/pages/repositories/kubescape.md
@@ -2,17 +2,31 @@
 # Kubescape
 
 ## Description
+
 Plural will install Kubescape in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Kubescape for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install kubescape kubescape-aws {% endtab %} {% tab title="AZURE" %} plural bundle install kubescape kubescape-azure {% endtab %} {% tab title="GCP" %} plural bundle install kubescape kubescape-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install kubescape kubescape-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install kubescape kubescape-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install kubescape kubescape-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `accountGuid`: Unique identifier connecting results to the Kubescape Cloud account. To learn more go here https://hub.armosec.io/docs/kubescape-cloud-account#account-id
-    
+
+

--- a/pages/repositories/metabase.md
+++ b/pages/repositories/metabase.md
@@ -1,0 +1,22 @@
+
+# Metabase
+
+## Description
+Plural will install Metabase in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Metabase for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install metabase metabase-aws {% endtab %} {% tab title="AZURE" %} plural bundle install metabase metabase-azure {% endtab %} {% tab title="GCP" %} plural bundle install metabase metabase-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`hostname`: fqdn for your metabase instance
+    

--- a/pages/repositories/metabase.md
+++ b/pages/repositories/metabase.md
@@ -2,16 +2,29 @@
 # Metabase
 
 ## Description
+
 Plural will install Metabase in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Metabase for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install metabase metabase-aws {% endtab %} {% tab title="AZURE" %} plural bundle install metabase metabase-azure {% endtab %} {% tab title="GCP" %} plural bundle install metabase metabase-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install metabase metabase-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install metabase metabase-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install metabase metabase-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -19,4 +32,5 @@ We currently support Metabase for the following providers:
 `wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
 `hostname`: fqdn for your metabase instance
-    
+
+

--- a/pages/repositories/minecraft.md
+++ b/pages/repositories/minecraft.md
@@ -2,17 +2,31 @@
 # Minecraft
 
 ## Description
+
 Plural will install Minecraft in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Minecraft for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install minecraft minecraft-aws {% endtab %} {% tab title="AZURE" %} plural bundle install minecraft minecraft-azure {% endtab %} {% tab title="GCP" %} plural bundle install minecraft minecraft-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install minecraft minecraft-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install minecraft minecraft-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install minecraft minecraft-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `hostname`: fqdn for your metabase instance
-    
+
+

--- a/pages/repositories/minecraft.md
+++ b/pages/repositories/minecraft.md
@@ -1,0 +1,18 @@
+
+# Minecraft
+
+## Description
+Plural will install Minecraft in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Minecraft for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install minecraft minecraft-aws {% endtab %} {% tab title="AZURE" %} plural bundle install minecraft minecraft-azure {% endtab %} {% tab title="GCP" %} plural bundle install minecraft minecraft-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`hostname`: fqdn for your metabase instance
+    

--- a/pages/repositories/minio.md
+++ b/pages/repositories/minio.md
@@ -2,16 +2,35 @@
 # Minio
 
 ## Description
+
 Plural will install Minio in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Minio for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install minio minio-aws {% endtab %} {% tab title="AZURE" %} plural bundle install minio minio-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install minio minio-equinix {% endtab %} {% tab title="GCP" %} plural bundle install minio minio-gcp {% endtab %} {% tab title="KIND" %} plural bundle install minio minio-kind {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install minio minio-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install minio minio-azure
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install minio minio-equinix
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install minio minio-gcp
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install minio minio-kind
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -23,4 +42,5 @@ We currently support Minio for the following providers:
 `hostname`: Fully Qualified Domain Name to use for your minio gateway installation, eg minio.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
 
 `consoleHostname`: Fully Qualified Domain Name to use for your minio console installation, eg minio.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
-    
+
+

--- a/pages/repositories/minio.md
+++ b/pages/repositories/minio.md
@@ -1,0 +1,26 @@
+
+# Minio
+
+## Description
+Plural will install Minio in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Minio for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install minio minio-aws {% endtab %} {% tab title="AZURE" %} plural bundle install minio minio-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install minio minio-equinix {% endtab %} {% tab title="GCP" %} plural bundle install minio minio-gcp {% endtab %} {% tab title="KIND" %} plural bundle install minio minio-kind {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+`minio_bucket`: bucket to store minio data
+
+`hostname`: Fully Qualified Domain Name to use for your minio gateway installation, eg minio.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
+
+`consoleHostname`: Fully Qualified Domain Name to use for your minio console installation, eg minio.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
+    

--- a/pages/repositories/mlflow.md
+++ b/pages/repositories/mlflow.md
@@ -1,0 +1,24 @@
+
+# Mlflow
+
+## Description
+Plural will install Mlflow in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Mlflow for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install mlflow mlflow-aws {% endtab %} {% tab title="AZURE" %} plural bundle install mlflow mlflow-azure {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`mlflow_bucket`: bucket to store the mlflow artifacts in
+
+`hostname`: FQDN to use for your MLFlow installation
+    

--- a/pages/repositories/mlflow.md
+++ b/pages/repositories/mlflow.md
@@ -2,16 +2,26 @@
 # Mlflow
 
 ## Description
+
 Plural will install Mlflow in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Mlflow for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install mlflow mlflow-aws {% endtab %} {% tab title="AZURE" %} plural bundle install mlflow mlflow-azure {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install mlflow mlflow-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install mlflow mlflow-azure
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -21,4 +31,5 @@ We currently support Mlflow for the following providers:
 `mlflow_bucket`: bucket to store the mlflow artifacts in
 
 `hostname`: FQDN to use for your MLFlow installation
-    
+
+

--- a/pages/repositories/mongodb.md
+++ b/pages/repositories/mongodb.md
@@ -2,17 +2,31 @@
 # Mongodb
 
 ## Description
+
 Plural will install Mongodb in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Mongodb for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install mongodb mongodb-aws {% endtab %} {% tab title="AZURE" %} plural bundle install mongodb mongodb-azure {% endtab %} {% tab title="GCP" %} plural bundle install mongodb mongodb-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install mongodb mongodb-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install mongodb mongodb-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install mongodb mongodb-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/mongodb.md
+++ b/pages/repositories/mongodb.md
@@ -1,0 +1,18 @@
+
+# Mongodb
+
+## Description
+Plural will install Mongodb in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Mongodb for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install mongodb mongodb-aws {% endtab %} {% tab title="AZURE" %} plural bundle install mongodb mongodb-azure {% endtab %} {% tab title="GCP" %} plural bundle install mongodb mongodb-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/mysql.md
+++ b/pages/repositories/mysql.md
@@ -1,0 +1,20 @@
+
+# Mysql
+
+## Description
+Plural will install Mysql in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Mysql for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install mysql aws-mysql {% endtab %} {% tab title="AWS" %} plural bundle install mysql aws-mysql-percona {% endtab %} {% tab title="GCP" %} plural bundle install mysql gcp-mysql {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`backup_bucket`: bucket to store mysql backups in
+
+`hostname`: FQDN to use for your accessing the mysql orchestrator
+    

--- a/pages/repositories/mysql.md
+++ b/pages/repositories/mysql.md
@@ -2,19 +2,33 @@
 # Mysql
 
 ## Description
+
 Plural will install Mysql in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Mysql for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install mysql aws-mysql {% endtab %} {% tab title="AWS" %} plural bundle install mysql aws-mysql-percona {% endtab %} {% tab title="GCP" %} plural bundle install mysql gcp-mysql {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install mysql aws-mysql
+{% /tab %}
+{% tab title="AWS" %}
+plural bundle install mysql aws-mysql-percona
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install mysql gcp-mysql
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `backup_bucket`: bucket to store mysql backups in
 
 `hostname`: FQDN to use for your accessing the mysql orchestrator
-    
+
+

--- a/pages/repositories/n8n.md
+++ b/pages/repositories/n8n.md
@@ -2,16 +2,29 @@
 # N8n
 
 ## Description
+
 Plural will install N8n in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support N8n for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install n8n n8n-aws {% endtab %} {% tab title="AZURE" %} plural bundle install n8n n8n-azure {% endtab %} {% tab title="GCP" %} plural bundle install n8n n8n-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install n8n n8n-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install n8n n8n-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install n8n n8n-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -19,4 +32,5 @@ We currently support N8n for the following providers:
 `wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
 `hostname`: domain on which you'd like to host n8n's page
-    
+
+

--- a/pages/repositories/n8n.md
+++ b/pages/repositories/n8n.md
@@ -1,0 +1,22 @@
+
+# N8n
+
+## Description
+Plural will install N8n in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support N8n for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install n8n n8n-aws {% endtab %} {% tab title="AZURE" %} plural bundle install n8n n8n-azure {% endtab %} {% tab title="GCP" %} plural bundle install n8n n8n-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`hostname`: domain on which you'd like to host n8n's page
+    

--- a/pages/repositories/nextcloud.md
+++ b/pages/repositories/nextcloud.md
@@ -1,0 +1,20 @@
+
+# Nextcloud
+
+## Description
+Plural will install Nextcloud in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Nextcloud for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install nextcloud nextcloud-aws {% endtab %} {% tab title="AZURE" %} plural bundle install nextcloud nextcloud-azure {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`nextcloud_bucket`: bucket to store nextcloud data
+
+`hostname`: FQDN to use for your nextcloud installation
+    

--- a/pages/repositories/nextcloud.md
+++ b/pages/repositories/nextcloud.md
@@ -2,19 +2,30 @@
 # Nextcloud
 
 ## Description
+
 Plural will install Nextcloud in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Nextcloud for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install nextcloud nextcloud-aws {% endtab %} {% tab title="AZURE" %} plural bundle install nextcloud nextcloud-azure {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install nextcloud nextcloud-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install nextcloud nextcloud-azure
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `nextcloud_bucket`: bucket to store nextcloud data
 
 `hostname`: FQDN to use for your nextcloud installation
-    
+
+

--- a/pages/repositories/nocodb.md
+++ b/pages/repositories/nocodb.md
@@ -2,16 +2,29 @@
 # Nocodb
 
 ## Description
+
 Plural will install Nocodb in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Nocodb for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install nocodb nocodb-aws {% endtab %} {% tab title="AZURE" %} plural bundle install nocodb nocodb-azure {% endtab %} {% tab title="GCP" %} plural bundle install nocodb nocodb-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install nocodb nocodb-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install nocodb nocodb-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install nocodb nocodb-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -19,4 +32,5 @@ We currently support Nocodb for the following providers:
 `wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
 
 `hostname`: Fully Qualified Domain Name to use for your nocodb installation
-    
+
+

--- a/pages/repositories/nocodb.md
+++ b/pages/repositories/nocodb.md
@@ -1,0 +1,22 @@
+
+# Nocodb
+
+## Description
+Plural will install Nocodb in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Nocodb for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install nocodb nocodb-aws {% endtab %} {% tab title="AZURE" %} plural bundle install nocodb nocodb-azure {% endtab %} {% tab title="GCP" %} plural bundle install nocodb nocodb-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`hostname`: Fully Qualified Domain Name to use for your nocodb installation
+    

--- a/pages/repositories/plural.md
+++ b/pages/repositories/plural.md
@@ -1,0 +1,54 @@
+
+# Plural
+
+## Description
+Plural will install Plural in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Plural for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install plural plural-aws {% endtab %} {% tab title="GCP" %} plural bundle install plural plural-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`enableChronograf`: whether to deploy the chronograf web ui
+
+`chronografHostname`: Fully Qualified Domain Name for the chronograf web ui
+
+`enableKapacitor`: whether to deploy kapacitor alerting
+
+`enableTelegraf`: whether to deploy telegraf metrics collection
+
+`databaseName`: name for the initial bootstrapped database
+
+`influxdbHostname`: external dns name for your influxdb instance (leave empty if you don't want ingress)
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+
+
+`chartmuseum_bucket`: Bucket for helm charts
+
+`assets_bucket`: bucket for misc assets (docker imgs/terraform modules)
+
+`images_bucket`: bucket for images and icons
+
+`plural_dns`: FQDN to use for your plural cluster
+
+`plural_dkr_dns`: None
+
+`admin_name`: name for initial admin user
+
+`admin_email`: email for initial admin user
+
+`publisher`: name for initial publisher
+
+`publisher_description`: description for initial publisher
+
+`hydra_host`: the fqdn to use for hydra, for managing plural oauth
+    

--- a/pages/repositories/plural.md
+++ b/pages/repositories/plural.md
@@ -2,16 +2,26 @@
 # Plural
 
 ## Description
+
 Plural will install Plural in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Plural for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install plural plural-aws {% endtab %} {% tab title="GCP" %} plural bundle install plural plural-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install plural plural-aws
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install plural plural-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -51,4 +61,5 @@ We currently support Plural for the following providers:
 `publisher_description`: description for initial publisher
 
 `hydra_host`: the fqdn to use for hydra, for managing plural oauth
-    
+
+

--- a/pages/repositories/postgres.md
+++ b/pages/repositories/postgres.md
@@ -2,17 +2,37 @@
 # Postgres
 
 ## Description
+
 Plural will install Postgres in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Postgres for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install postgres aws-postgres {% endtab %} {% tab title="AZURE" %} plural bundle install postgres azure-postgres {% endtab %} {% tab title="EQUINIX" %} plural bundle install postgres equinix-postgres {% endtab %} {% tab title="GCP" %} plural bundle install postgres gcp-postgres {% endtab %} {% tab title="KIND" %} plural bundle install postgres kind-postgres {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install postgres aws-postgres
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install postgres azure-postgres
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install postgres equinix-postgres
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install postgres gcp-postgres
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install postgres kind-postgres
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
-    
+
+

--- a/pages/repositories/postgres.md
+++ b/pages/repositories/postgres.md
@@ -1,0 +1,18 @@
+
+# Postgres
+
+## Description
+Plural will install Postgres in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Postgres for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install postgres aws-postgres {% endtab %} {% tab title="AZURE" %} plural bundle install postgres azure-postgres {% endtab %} {% tab title="EQUINIX" %} plural bundle install postgres equinix-postgres {% endtab %} {% tab title="GCP" %} plural bundle install postgres gcp-postgres {% endtab %} {% tab title="KIND" %} plural bundle install postgres kind-postgres {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+    

--- a/pages/repositories/rabbitmq.md
+++ b/pages/repositories/rabbitmq.md
@@ -2,17 +2,31 @@
 # Rabbitmq
 
 ## Description
+
 Plural will install Rabbitmq in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Rabbitmq for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install rabbitmq rabbitmq-aws {% endtab %} {% tab title="AZURE" %} plural bundle install rabbitmq rabbitmq-azure {% endtab %} {% tab title="GCP" %} plural bundle install rabbitmq rabbitmq-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install rabbitmq rabbitmq-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install rabbitmq rabbitmq-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install rabbitmq rabbitmq-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/rabbitmq.md
+++ b/pages/repositories/rabbitmq.md
@@ -1,0 +1,18 @@
+
+# Rabbitmq
+
+## Description
+Plural will install Rabbitmq in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Rabbitmq for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install rabbitmq rabbitmq-aws {% endtab %} {% tab title="AZURE" %} plural bundle install rabbitmq rabbitmq-azure {% endtab %} {% tab title="GCP" %} plural bundle install rabbitmq rabbitmq-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/ray.md
+++ b/pages/repositories/ray.md
@@ -2,19 +2,33 @@
 # Ray
 
 ## Description
+
 Plural will install Ray in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Ray for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install ray ray-aws {% endtab %} {% tab title="AZURE" %} plural bundle install ray ray-azure {% endtab %} {% tab title="GCP" %} plural bundle install ray ray-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install ray ray-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install ray ray-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install ray ray-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
 
 `hostname`: domain on which you'd like to host RAY's page
-    
+
+

--- a/pages/repositories/ray.md
+++ b/pages/repositories/ray.md
@@ -1,0 +1,20 @@
+
+# Ray
+
+## Description
+Plural will install Ray in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Ray for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install ray ray-aws {% endtab %} {% tab title="AZURE" %} plural bundle install ray ray-azure {% endtab %} {% tab title="GCP" %} plural bundle install ray ray-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`hostname`: domain on which you'd like to host RAY's page
+    

--- a/pages/repositories/redis.md
+++ b/pages/repositories/redis.md
@@ -2,19 +2,33 @@
 # Redis
 
 ## Description
+
 Plural will install Redis in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Redis for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install redis aws-redis {% endtab %} {% tab title="AZURE" %} plural bundle install redis azure-redis {% endtab %} {% tab title="GCP" %} plural bundle install redis gcp-redis {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install redis aws-redis
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install redis azure-redis
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install redis gcp-redis
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `masterHostname`: the dns name to access the redis master (optional)
 
 `replicaHostname`: the dns name to access your redis replicas (optional)
-    
+
+

--- a/pages/repositories/redis.md
+++ b/pages/repositories/redis.md
@@ -1,0 +1,20 @@
+
+# Redis
+
+## Description
+Plural will install Redis in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Redis for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install redis aws-redis {% endtab %} {% tab title="AZURE" %} plural bundle install redis azure-redis {% endtab %} {% tab title="GCP" %} plural bundle install redis gcp-redis {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+    

--- a/pages/repositories/reloader.md
+++ b/pages/repositories/reloader.md
@@ -1,0 +1,18 @@
+
+# Reloader
+
+## Description
+Plural will install Reloader in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Reloader for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install reloader reloader-aws {% endtab %} {% tab title="AZURE" %} plural bundle install reloader reloader-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install reloader reloader-equinix {% endtab %} {% tab title="GCP" %} plural bundle install reloader reloader-gcp {% endtab %} {% tab title="KIND" %} plural bundle install reloader reloader-kind {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/reloader.md
+++ b/pages/repositories/reloader.md
@@ -2,17 +2,37 @@
 # Reloader
 
 ## Description
+
 Plural will install Reloader in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Reloader for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install reloader reloader-aws {% endtab %} {% tab title="AZURE" %} plural bundle install reloader reloader-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install reloader reloader-equinix {% endtab %} {% tab title="GCP" %} plural bundle install reloader reloader-gcp {% endtab %} {% tab title="KIND" %} plural bundle install reloader reloader-kind {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install reloader reloader-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install reloader reloader-azure
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install reloader reloader-equinix
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install reloader reloader-gcp
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install reloader reloader-kind
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/rook.md
+++ b/pages/repositories/rook.md
@@ -2,16 +2,32 @@
 # Rook
 
 ## Description
+
 Plural will install Rook in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Rook for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install rook rook-aws {% endtab %} {% tab title="AZURE" %} plural bundle install rook rook-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install rook rook-equinix {% endtab %} {% tab title="GCP" %} plural bundle install rook rook-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install rook rook-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install rook rook-azure
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install rook rook-equinix
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install rook rook-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -19,4 +35,5 @@ We currently support Rook for the following providers:
 `hostname`: FQDN to use for your the Ceph Dashboard
 
 `s3Hostname`: FQDN to use for your the S3 API endpoint
-    
+
+

--- a/pages/repositories/rook.md
+++ b/pages/repositories/rook.md
@@ -1,0 +1,22 @@
+
+# Rook
+
+## Description
+Plural will install Rook in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Rook for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install rook rook-aws {% endtab %} {% tab title="AZURE" %} plural bundle install rook rook-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install rook rook-equinix {% endtab %} {% tab title="GCP" %} plural bundle install rook rook-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`hostname`: FQDN to use for your the Ceph Dashboard
+
+`s3Hostname`: FQDN to use for your the S3 API endpoint
+    

--- a/pages/repositories/sentry.md
+++ b/pages/repositories/sentry.md
@@ -1,0 +1,34 @@
+
+# Sentry
+
+## Description
+Plural will install Sentry in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Sentry for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install sentry aws-sentry {% endtab %} {% tab title="AZURE" %} plural bundle install sentry azure-sentry {% endtab %} {% tab title="GCP" %} plural bundle install sentry gcp-sentry {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`masterHostname`: the dns name to access the redis master (optional)
+
+`replicaHostname`: the dns name to access your redis replicas (optional)
+
+
+
+`hostname`: hostname for your sentry instance
+
+`filestoreBucket`: s3 bucket to store miscellaneous files to
+
+`adminEmail`: admin user email
+    

--- a/pages/repositories/sentry.md
+++ b/pages/repositories/sentry.md
@@ -2,16 +2,29 @@
 # Sentry
 
 ## Description
+
 Plural will install Sentry in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Sentry for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install sentry aws-sentry {% endtab %} {% tab title="AZURE" %} plural bundle install sentry azure-sentry {% endtab %} {% tab title="GCP" %} plural bundle install sentry gcp-sentry {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install sentry aws-sentry
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install sentry azure-sentry
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install sentry gcp-sentry
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -31,4 +44,5 @@ We currently support Sentry for the following providers:
 `filestoreBucket`: s3 bucket to store miscellaneous files to
 
 `adminEmail`: admin user email
-    
+
+

--- a/pages/repositories/spark.md
+++ b/pages/repositories/spark.md
@@ -2,17 +2,31 @@
 # Spark
 
 ## Description
+
 Plural will install Spark in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Spark for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install spark spark-aws {% endtab %} {% tab title="AZURE" %} plural bundle install spark spark-azure {% endtab %} {% tab title="GCP" %} plural bundle install spark spark-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install spark spark-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install spark spark-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install spark spark-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
-    
+
+

--- a/pages/repositories/spark.md
+++ b/pages/repositories/spark.md
@@ -1,0 +1,18 @@
+
+# Spark
+
+## Description
+Plural will install Spark in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Spark for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install spark spark-aws {% endtab %} {% tab title="AZURE" %} plural bundle install spark spark-azure {% endtab %} {% tab title="GCP" %} plural bundle install spark spark-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+    

--- a/pages/repositories/superset.md
+++ b/pages/repositories/superset.md
@@ -1,0 +1,28 @@
+
+# Superset
+
+## Description
+Plural will install Superset in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Superset for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install superset superset-aws {% endtab %} {% tab title="AZURE" %} plural bundle install superset superset-azure {% endtab %} {% tab title="GCP" %} plural bundle install superset superset-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`hostname`: Fully Qualified Domain Name to use for your superset installation, eg airflow.topleveldomain.com if topleveldomain.com is the domain you inputed for dns_domain above.
+
+`username`: short name/handle for the initial admin user
+
+`name`: full name for the initial admin user
+
+`adminEmail`: email for the initial admin user
+    

--- a/pages/repositories/superset.md
+++ b/pages/repositories/superset.md
@@ -2,16 +2,29 @@
 # Superset
 
 ## Description
+
 Plural will install Superset in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Superset for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install superset superset-aws {% endtab %} {% tab title="AZURE" %} plural bundle install superset superset-azure {% endtab %} {% tab title="GCP" %} plural bundle install superset superset-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install superset superset-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install superset superset-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install superset superset-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -25,4 +38,5 @@ We currently support Superset for the following providers:
 `name`: full name for the initial admin user
 
 `adminEmail`: email for the initial admin user
-    
+
+

--- a/pages/repositories/terraria.md
+++ b/pages/repositories/terraria.md
@@ -2,16 +2,35 @@
 # Terraria
 
 ## Description
+
 Plural will install Terraria in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Terraria for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install terraria terraria-aws {% endtab %} {% tab title="AZURE" %} plural bundle install terraria terraria-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install terraria terraria-equinix {% endtab %} {% tab title="GCP" %} plural bundle install terraria terraria-gcp {% endtab %} {% tab title="KIND" %} plural bundle install terraria terraria-kind {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install terraria terraria-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install terraria terraria-azure
+{% /tab %}
+{% tab title="EQUINIX" %}
+plural bundle install terraria terraria-equinix
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install terraria terraria-gcp
+{% /tab %}
+{% tab title="KIND" %}
+plural bundle install terraria terraria-kind
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 `hostname`: domain on which you'd like to host your terraria server
@@ -21,4 +40,5 @@ We currently support Terraria for the following providers:
 `password`: password that will be required when joining the server (leave empty to disable)
 
 `restAPIEnabled`: if additional rest API should be enabled and exposed on port 7878 (Y/n)
-    
+
+

--- a/pages/repositories/terraria.md
+++ b/pages/repositories/terraria.md
@@ -1,0 +1,24 @@
+
+# Terraria
+
+## Description
+Plural will install Terraria in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Terraria for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install terraria terraria-aws {% endtab %} {% tab title="AZURE" %} plural bundle install terraria terraria-azure {% endtab %} {% tab title="EQUINIX" %} plural bundle install terraria terraria-equinix {% endtab %} {% tab title="GCP" %} plural bundle install terraria terraria-gcp {% endtab %} {% tab title="KIND" %} plural bundle install terraria terraria-kind {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+`hostname`: domain on which you'd like to host your terraria server
+
+`worldsize`: size of the world you would like to be generated (small|medium|large)
+
+`password`: password that will be required when joining the server (leave empty to disable)
+
+`restAPIEnabled`: if additional rest API should be enabled and exposed on port 7878 (Y/n)
+    

--- a/pages/repositories/touca.md
+++ b/pages/repositories/touca.md
@@ -2,16 +2,26 @@
 # Touca
 
 ## Description
+
 Plural will install Touca in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Touca for the following providers:
 
 {% tabs %}
-{% tab title="AZURE" %} plural bundle install touca touca-azure {% endtab %} {% tab title="GCP" %} plural bundle install touca touca-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AZURE" %}
+plural bundle install touca touca-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install touca touca-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `network_name`: Arbitary name for the network to place your cluster in, eg "plural"
 
 
@@ -19,4 +29,5 @@ We currently support Touca for the following providers:
 
 
 `hostname`: the fully qualified domain name your touca instance will be available at
-    
+
+

--- a/pages/repositories/touca.md
+++ b/pages/repositories/touca.md
@@ -1,0 +1,22 @@
+
+# Touca
+
+## Description
+Plural will install Touca in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Touca for the following providers:
+
+{% tabs %}
+{% tab title="AZURE" %} plural bundle install touca touca-azure {% endtab %} {% tab title="GCP" %} plural bundle install touca touca-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`network_name`: Arbitary name for the network to place your cluster in, eg "plural"
+
+
+
+
+
+`hostname`: the fully qualified domain name your touca instance will be available at
+    

--- a/pages/repositories/trino.md
+++ b/pages/repositories/trino.md
@@ -2,19 +2,33 @@
 # Trino
 
 ## Description
+
 Plural will install Trino in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Trino for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install trino trino-aws {% endtab %} {% tab title="AZURE" %} plural bundle install trino trino-azure {% endtab %} {% tab title="GCP" %} plural bundle install trino trino-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install trino trino-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install trino trino-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install trino trino-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
 
 `hostname`: domain on which you'd like to host trino's web interface
-    
+
+

--- a/pages/repositories/trino.md
+++ b/pages/repositories/trino.md
@@ -1,0 +1,20 @@
+
+# Trino
+
+## Description
+Plural will install Trino in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Trino for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install trino trino-aws {% endtab %} {% tab title="AZURE" %} plural bundle install trino trino-azure {% endtab %} {% tab title="GCP" %} plural bundle install trino trino-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`hostname`: domain on which you'd like to host trino's web interface
+    

--- a/pages/repositories/vault.md
+++ b/pages/repositories/vault.md
@@ -2,19 +2,33 @@
 # Vault
 
 ## Description
+
 Plural will install Vault in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Vault for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install vault vault-aws {% endtab %} {% tab title="AZURE" %} plural bundle install vault vault-azure {% endtab %} {% tab title="GCP" %} plural bundle install vault vault-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install vault vault-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install vault vault-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install vault vault-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
 
 `hostname`: FQDN to use for your Vault installation
-    
+
+

--- a/pages/repositories/vault.md
+++ b/pages/repositories/vault.md
@@ -1,0 +1,20 @@
+
+# Vault
+
+## Description
+Plural will install Vault in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Vault for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install vault vault-aws {% endtab %} {% tab title="AZURE" %} plural bundle install vault vault-azure {% endtab %} {% tab title="GCP" %} plural bundle install vault vault-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`hostname`: FQDN to use for your Vault installation
+    

--- a/pages/repositories/vaultwarden.md
+++ b/pages/repositories/vaultwarden.md
@@ -2,16 +2,29 @@
 # Vaultwarden
 
 ## Description
+
 Plural will install Vaultwarden in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
 
 ## Installation
+
 We currently support Vaultwarden for the following providers:
 
 {% tabs %}
-{% tab title="AWS" %} plural bundle install vaultwarden vaultwarden-aws {% endtab %} {% tab title="AZURE" %} plural bundle install vaultwarden vaultwarden-azure {% endtab %} {% tab title="GCP" %} plural bundle install vaultwarden vaultwarden-gcp {% endtab %}
-{% endtabs %}
+
+{% tab title="AWS" %}
+plural bundle install vaultwarden vaultwarden-aws
+{% /tab %}
+{% tab title="AZURE" %}
+plural bundle install vaultwarden vaultwarden-azure
+{% /tab %}
+{% tab title="GCP" %}
+plural bundle install vaultwarden vaultwarden-gcp
+{% /tab %}
+
+{% /tabs %}
 
 ## Setup Configuration
+
 `vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
 
 
@@ -21,4 +34,5 @@ We currently support Vaultwarden for the following providers:
 `hostname`: FQDN to use for your Vaultwarden installation
 
 `signupDomains`: comma separated list of domains to allow for user signup
-    
+
+

--- a/pages/repositories/vaultwarden.md
+++ b/pages/repositories/vaultwarden.md
@@ -1,0 +1,24 @@
+
+# Vaultwarden
+
+## Description
+Plural will install Vaultwarden in a dependency-aware manner onto a Plural-managed Kubernetes cluster with one CLI command.
+
+## Installation
+We currently support Vaultwarden for the following providers:
+
+{% tabs %}
+{% tab title="AWS" %} plural bundle install vaultwarden vaultwarden-aws {% endtab %} {% tab title="AZURE" %} plural bundle install vaultwarden vaultwarden-azure {% endtab %} {% tab title="GCP" %} plural bundle install vaultwarden vaultwarden-gcp {% endtab %}
+{% endtabs %}
+
+## Setup Configuration
+`vpc_name`: Arbitary name for the virtual private cloud to place your cluster in, eg "plural"
+
+
+
+`wal_bucket`: Arbitary name for s3 bucket to store wal archives in, eg plural-wal-archives
+
+`hostname`: FQDN to use for your Vaultwarden installation
+
+`signupDomains`: comma separated list of domains to allow for user signup
+    


### PR DESCRIPTION
👍 

Added or modified: 
```js
  'airbyte',
  'console',
  'airflow',
  'argo-cd',
  'argo-workflows',
  'chatwoot',
  'crossplane',
  'dagster',
  'datahub',
  'etcd',
  'filecoin',
  'ghost',
  'gitlab',
  'grafana',
  'grafana-tempo',
  'growthbook',
  'hasura',
  'influx',
  'ingress-nginx',
  'istio',
  'jitsu',
  'kafka',
  'knative',
  'kserve',
  'kubecost',
  'kubeflow',
  'kubescape',
  'metabase',
  'minecraft',
  'minio',
  'mlflow',
  'mongodb',
  'mysql',
  'n8n',
  'nextcloud',
  'nocodb',
  'oncall',
  'plural',
  'postgres',
  'rabbitmq',
  'ray',
  'redis',
  'reloader',
  'rook',
  'sentry',
  'spark',
  'superset',
  'terraria',
  'touca',
  'trino',
  'valheim',
  'vault',
  'vaultwarden',
```

Missing:
- oncall
- grafana-tempo

For script failure reasons.