### PR TITLE
Add redirection for /getting-started

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -37,6 +37,11 @@ module.exports = () => {
           permanent: true,
         },
         {
+          source: '/getting-started',
+          destination: '/getting-started/quickstart',
+          permanent: true,
+        },
+        {
           source: '/reference/architecture-1',
           destination: '/reference/architecture',
           permanent: true,


### PR DESCRIPTION
We link to this often and it's now broken, so adding a redirect.