### PR TITLE
fix: Google analytics wasn't working

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -58,10 +58,10 @@ class MyDocument extends Document {
           <script dangerouslySetInnerHTML={{
             __html: `window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
 gtag('consent', 'default', {ad_storage:'denied', analytics_storage:'denied'});
 gtag('set', 'ads_data_redaction', true);
 gtag('set', 'url_passthrough', true);
+gtag('js', new Date());
 gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');`,
           }}
           />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -53,19 +53,18 @@ class MyDocument extends Document {
           />
           <script
             async
-            src="https://www.googletagmanager.com/gtag/js?id=G-ND8K98HK0J"
+            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
           />
-          <script>
-            {`
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('consent', 'default', {ad_storage:'denied', analytics_storage:'denied'});
-  gtag('set', 'ads_data_redaction', true);
-  gtag('set', 'url_passthrough', true);
-  gtag('config', 'G-ND8K98HK0J');
-  `}
-          </script>
+          <script dangerouslySetInnerHTML={{
+            __html: `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('consent', 'default', {ad_storage:'denied', analytics_storage:'denied'});
+gtag('set', 'ads_data_redaction', true);
+gtag('set', 'url_passthrough', true);
+gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}');`,
+          }}
+          />
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -30,6 +30,7 @@ class MyDocument extends Document {
     }
   }
 
+  // Using gtag with Cookiebot: https://support.cookiebot.com/hc/en-us/articles/360003979074-Using-Google-Gtag-with-Cookiebot
   render() {
     return (
       <Html data-theme="dark">
@@ -50,6 +51,21 @@ class MyDocument extends Document {
             type="text/javascript"
             data-widget-position="bottom-right"
           />
+          <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-ND8K98HK0J"
+          />
+          <script>
+            {`
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('consent', 'default', {ad_storage:'denied', analytics_storage:'denied'});
+  gtag('set', 'ads_data_redaction', true);
+  gtag('set', 'url_passthrough', true);
+  gtag('config', 'G-ND8K98HK0J');
+  `}
+          </script>
         </Head>
         <body>
           <Main />

--- a/src/components/ExternalScripts.tsx
+++ b/src/components/ExternalScripts.tsx
@@ -60,13 +60,16 @@ function HubSpot() {
   )
 }
 
+function gtag(..._: any) {
+  console.log('gtag', _)
+  const dataLayer = (window.dataLayer = window.dataLayer || [])
+
+  // Trying not to rewrite what google provides
+  // eslint-disable-next-line prefer-rest-params
+  dataLayer.push(arguments)
+}
+
 function Gtag() {
-  const gtag = useCallback<(...args: any[]) => void>((...args) => {
-    const dataLayer = (window.dataLayer = window.dataLayer || [])
-
-    dataLayer.push(...args)
-  }, [])
-
   useEffect(() => {
     window[`ga-disable-${process.env.NEXT_PUBLIC_GA_ID}`] = true
 
@@ -78,7 +81,7 @@ function Gtag() {
     })
     gtag('js', new Date())
     gtag('config', process.env.NEXT_PUBLIC_GA_ID)
-  }, [gtag])
+  }, [])
 
   // Turn tracking on and off when cookie prefs change
   useEffect(() => {
@@ -101,7 +104,7 @@ function Gtag() {
       window.removeEventListener('CookiebotOnAccept', onCookiePrefChange)
       window.removeEventListener('CookiebotOnDecline', onCookiePrefChange)
     }
-  }, [gtag])
+  }, [])
 
   return (
     <Script

--- a/src/components/ExternalScripts.tsx
+++ b/src/components/ExternalScripts.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 
 import { useRouter } from 'next/router'
 import Script from 'next/script'

--- a/src/components/ExternalScripts.tsx
+++ b/src/components/ExternalScripts.tsx
@@ -68,15 +68,21 @@ function gtag(..._: any) {
   dataLayer.push(arguments)
 }
 
+function getGtagStorageConsent() {
+  const consent = window.Cookiebot?.consent
+
+  return {
+    ad_storage: consent?.marketing ? 'granted' : 'denied',
+    analytics_storage: consent?.statistics ? 'granted' : 'denied',
+    personalization_storage: consent?.preferences ? 'granted' : 'denied',
+  }
+}
+
 function Gtag() {
   useEffect(() => {
-    window[`ga-disable-${process.env.NEXT_PUBLIC_GA_ID}`] = true
-
-    gtag('set', { allow_google_signals: false })
-    gtag('set', { allow_ad_personalization_signals: false })
     gtag('consent', 'default', {
-      ad_storage: 'denied',
-      analytics_storage: 'denied',
+      ...getGtagStorageConsent(),
+      wait_for_update: 1000,
     })
     gtag('js', new Date())
     gtag('config', process.env.NEXT_PUBLIC_GA_ID)
@@ -85,15 +91,9 @@ function Gtag() {
   // Turn tracking on and off when cookie prefs change
   useEffect(() => {
     const onCookiePrefChange = () => {
-      const allowStats = window.Cookiebot?.consent?.statistics
-      const allowMarketing = window.Cookiebot?.consent?.marketing
-
-      gtag('set', { allow_google_signals: allowMarketing })
       gtag('consent', 'update', {
-        ad_storage: allowMarketing ? 'granted' : 'denied',
-        analytics_storage: allowStats ? 'granted' : 'denied',
+        ...getGtagStorageConsent(),
       })
-      window[`ga-disable-${process.env.NEXT_PUBLIC_GA_ID}`] = !allowStats
     }
 
     window.addEventListener('CookiebotOnAccept', onCookiePrefChange)

--- a/src/components/ExternalScripts.tsx
+++ b/src/components/ExternalScripts.tsx
@@ -72,23 +72,24 @@ function Gtag() {
   // Cookiebot will automatically turn on/off gtag tracking when prefs change
   // https://support.cookiebot.com/hc/en-us/articles/360003979074-Using-Google-Gtag-with-Cookiebot
 
+  useEffect(() => {
+    const consent = window.Cookiebot?.consent
+
+    gtag('consent', 'default', {
+      ad_storage: consent?.marketing ? 'granted' : 'denied',
+      analytics_storage: consent?.statistics ? 'granted' : 'denied',
+      personalization_storage: consent?.preferences ? 'granted' : 'denied',
+    })
+    gtag('set', 'ads_data_redaction', !consent?.marketing)
+    gtag('set', 'url_passthrough', true)
+    gtag('js', new Date())
+    gtag('config', process.env.NEXT_PUBLIC_GA_ID)
+  }, [])
+
   return (
     <Script
       strategy="afterInteractive"
       src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
-      onLoad={() => {
-        const consent = window.Cookiebot?.consent
-
-        gtag('consent', 'default', {
-          ad_storage: consent?.marketing ? 'granted' : 'denied',
-          analytics_storage: consent?.statistics ? 'granted' : 'denied',
-          personalization_storage: consent?.preferences ? 'granted' : 'denied',
-        })
-        gtag('set', 'ads_data_redaction', !consent?.marketing)
-        gtag('set', 'url_passthrough', true)
-        gtag('js', new Date())
-        gtag('config', process.env.NEXT_PUBLIC_GA_ID)
-      }}
     />
   )
 }

--- a/src/components/ExternalScripts.tsx
+++ b/src/components/ExternalScripts.tsx
@@ -68,47 +68,27 @@ function gtag(..._: any) {
   dataLayer.push(arguments)
 }
 
-function getGtagStorageConsent() {
-  const consent = window.Cookiebot?.consent
-
-  return {
-    ad_storage: consent?.marketing ? 'granted' : 'denied',
-    analytics_storage: consent?.statistics ? 'granted' : 'denied',
-    personalization_storage: consent?.preferences ? 'granted' : 'denied',
-  }
-}
-
 function Gtag() {
-  useEffect(() => {
-    gtag('consent', 'default', {
-      ...getGtagStorageConsent(),
-      wait_for_update: 1000,
-    })
-    gtag('js', new Date())
-    gtag('config', process.env.NEXT_PUBLIC_GA_ID)
-  }, [])
-
-  // Turn tracking on and off when cookie prefs change
-  useEffect(() => {
-    const onCookiePrefChange = () => {
-      gtag('consent', 'update', {
-        ...getGtagStorageConsent(),
-      })
-    }
-
-    window.addEventListener('CookiebotOnAccept', onCookiePrefChange)
-    window.addEventListener('CookiebotOnDecline', onCookiePrefChange)
-
-    return () => {
-      window.removeEventListener('CookiebotOnAccept', onCookiePrefChange)
-      window.removeEventListener('CookiebotOnDecline', onCookiePrefChange)
-    }
-  }, [])
+  // Cookiebot will automatically turn on/off gtag tracking when prefs change
+  // https://support.cookiebot.com/hc/en-us/articles/360003979074-Using-Google-Gtag-with-Cookiebot
 
   return (
     <Script
       strategy="afterInteractive"
       src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
+      onLoad={() => {
+        const consent = window.Cookiebot?.consent
+
+        gtag('consent', 'default', {
+          ad_storage: consent?.marketing ? 'granted' : 'denied',
+          analytics_storage: consent?.statistics ? 'granted' : 'denied',
+          personalization_storage: consent?.preferences ? 'granted' : 'denied',
+        })
+        gtag('set', 'ads_data_redaction', !consent?.marketing)
+        gtag('set', 'url_passthrough', true)
+        gtag('js', new Date())
+        gtag('config', process.env.NEXT_PUBLIC_GA_ID)
+      }}
     />
   )
 }

--- a/src/components/ExternalScripts.tsx
+++ b/src/components/ExternalScripts.tsx
@@ -60,45 +60,6 @@ function HubSpot() {
   )
 }
 
-function gtag(..._: any) {
-  const dataLayer = (window.dataLayer = window.dataLayer || [])
-
-  // Trying not to rewrite what google provides
-  // eslint-disable-next-line prefer-rest-params
-  dataLayer.push(arguments)
-}
-
-function Gtag() {
-  // Cookiebot will automatically turn on/off gtag tracking when prefs change
-  // https://support.cookiebot.com/hc/en-us/articles/360003979074-Using-Google-Gtag-with-Cookiebot
-
-  useEffect(() => {
-    const consent = window.Cookiebot?.consent
-
-    gtag('consent', 'default', {
-      ad_storage: consent?.marketing ? 'granted' : 'denied',
-      analytics_storage: consent?.statistics ? 'granted' : 'denied',
-      personalization_storage: consent?.preferences ? 'granted' : 'denied',
-    })
-    gtag('set', 'ads_data_redaction', !consent?.marketing)
-    gtag('set', 'url_passthrough', true)
-    gtag('js', new Date())
-    gtag('config', process.env.NEXT_PUBLIC_GA_ID)
-  }, [])
-
-  return (
-    <Script
-      strategy="afterInteractive"
-      src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
-    />
-  )
-}
-
 export default function ExternalScripts() {
-  return (
-    <>
-      <Gtag />
-      <HubSpot />
-    </>
-  )
+  return <HubSpot />
 }

--- a/src/components/ExternalScripts.tsx
+++ b/src/components/ExternalScripts.tsx
@@ -61,7 +61,6 @@ function HubSpot() {
 }
 
 function gtag(..._: any) {
-  console.log('gtag', _)
   const dataLayer = (window.dataLayer = window.dataLayer || [])
 
   // Trying not to rewrite what google provides

--- a/src/components/types/window.d.ts
+++ b/src/components/types/window.d.ts
@@ -1,10 +1,32 @@
 interface Window {
   Cookiebot?: {
     consent?: {
+      necessary: boolean
+      preferences: boolean
       statistics: boolean
       marketing: boolean
+      method: string | null
     }
-    show: () => void
+    consented: boolean
+    declined: boolean
+    hasResponse: boolean
+    doNotTrack: boolean
+    regulations: {
+      gdprApplies: boolean
+      ccpaApplies: boolean
+      lgpdApplies: boolean
+    }
+    show(): void
+    hide(): void
+    renew(): void
+    getScript(url: string, async: boolean, callback: () => void): void
+    runScripts(): void
+    withdraw(): void
+    submitCustomConsent(
+      optinPreferences: boolean,
+      optinStatistics: boolean,
+      optinMarketing: boolean
+    ): void
   }
   // Hubspot
   _hsq?: any[]

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -4453,6 +4453,8 @@ export type User = {
   boundRoles?: Maybe<Array<Maybe<Role>>>;
   cards?: Maybe<CardConnection>;
   defaultQueueId?: Maybe<Scalars['ID']>;
+  /** If a user has reached the demo project usage limit. */
+  demoed?: Maybe<Scalars['Boolean']>;
   demoing?: Maybe<Scalars['Boolean']>;
   email: Scalars['String'];
   emailConfirmBy?: Maybe<Scalars['DateTime']>;

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -374,6 +374,8 @@ export type Cluster = {
   /** The source of the cluster. */
   source?: Maybe<Source>;
   updatedAt?: Maybe<Scalars['DateTime']>;
+  /** pending upgrades for each installed app */
+  upgradeInfo?: Maybe<Array<Maybe<UpgradeInfo>>>;
 };
 
 /** Input for creating or updating a cluster. */
@@ -396,6 +398,18 @@ export type ClusterConnection = {
   __typename?: 'ClusterConnection';
   edges?: Maybe<Array<Maybe<ClusterEdge>>>;
   pageInfo: PageInfo;
+};
+
+/** A dependncy reference between clusters */
+export type ClusterDependency = {
+  __typename?: 'ClusterDependency';
+  /** the cluster holding this dependency */
+  cluster?: Maybe<Cluster>;
+  /** the source cluster of this dependency */
+  dependency?: Maybe<Cluster>;
+  id: Scalars['ID'];
+  insertedAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
 };
 
 export type ClusterEdge = {
@@ -494,6 +508,13 @@ export enum Datatype {
   String = 'STRING'
 }
 
+export type DeferredReason = {
+  __typename?: 'DeferredReason';
+  message?: Maybe<Scalars['String']>;
+  package?: Maybe<Scalars['String']>;
+  repository?: Maybe<Scalars['String']>;
+};
+
 export type DeferredUpdate = {
   __typename?: 'DeferredUpdate';
   attempts?: Maybe<Scalars['Int']>;
@@ -501,6 +522,8 @@ export type DeferredUpdate = {
   dequeueAt?: Maybe<Scalars['DateTime']>;
   id: Scalars['ID'];
   insertedAt?: Maybe<Scalars['DateTime']>;
+  messages?: Maybe<Array<Maybe<DeferredReason>>>;
+  pending?: Maybe<Scalars['Boolean']>;
   terraformInstallation?: Maybe<TerraformInstallation>;
   updatedAt?: Maybe<Scalars['DateTime']>;
   version?: Maybe<Version>;
@@ -2480,6 +2503,8 @@ export type RootMutationType = {
   createCard?: Maybe<Account>;
   /** Create a new cluster. */
   createCluster?: Maybe<Cluster>;
+  /** adds a dependency for this cluster to gate future upgrades */
+  createClusterDependency?: Maybe<ClusterDependency>;
   createCrd?: Maybe<Crd>;
   createDemoProject?: Maybe<DemoProject>;
   createDnsRecord?: Maybe<DnsRecord>;
@@ -2560,6 +2585,8 @@ export type RootMutationType = {
   oauthConsent?: Maybe<OauthResponse>;
   passwordlessLogin?: Maybe<User>;
   pingWebhook?: Maybe<WebhookResponse>;
+  /** moves up the upgrade waterline for a user */
+  promote?: Maybe<User>;
   provisionDomain?: Maybe<DnsDomain>;
   publishLogs?: Maybe<TestStep>;
   quickStack?: Maybe<Stack>;
@@ -2646,6 +2673,12 @@ export type RootMutationTypeCreateCardArgs = {
 
 export type RootMutationTypeCreateClusterArgs = {
   attributes: ClusterAttributes;
+};
+
+
+export type RootMutationTypeCreateClusterDependencyArgs = {
+  destId: Scalars['ID'];
+  sourceId: Scalars['ID'];
 };
 
 
@@ -4399,6 +4432,13 @@ export type UpgradeEdge = {
   __typename?: 'UpgradeEdge';
   cursor?: Maybe<Scalars['String']>;
   node?: Maybe<Upgrade>;
+};
+
+/** The pending upgrades for a repository */
+export type UpgradeInfo = {
+  __typename?: 'UpgradeInfo';
+  count?: Maybe<Scalars['Int']>;
+  installation?: Maybe<Installation>;
 };
 
 export type UpgradeQueue = {


### PR DESCRIPTION
gtag events weren't actually firing, and it turns out cookiebot had automatic support for managing gtag's consent mode, so just using the bare minimum gtag snippet works better.

Not necessary, but updated the TS interface for Cookiebot to be more complete for good measure.

Also a bunch of autogenerated graphql stuff changed.