### PR TITLE
fix sharing git repo docs

### DIFF
--- a/pages/getting-started/manage-git-repositories/sharing-git-repositories.md
+++ b/pages/getting-started/manage-git-repositories/sharing-git-repositories.md
@@ -45,3 +45,20 @@ plural deploy
 git add . && git commit -m "set up encryption"
 git push
 ```
+
+### Decrypt the repository
+
+There are two ways the person you shared encryption can decrypt the repository. The simplest is to use the `plural clone` command:
+
+```shell
+plural clone git@github.com:your/repository.git
+```
+
+This will both run a standard git clone and then the following commands:
+
+```shell
+plural crypto init
+plural crypto unlock
+```
+
+If you chose to run a standard `git clone``, the above commands would still be required.


### PR DESCRIPTION
## Summary
the sharing doc doesn't actually give decryption instructions, this should fix

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.