### PR TITLE
Add login to setup-keys docs

### DIFF
--- a/pages/getting-started/manage-git-repositories/sharing-git-repositories.md
+++ b/pages/getting-started/manage-git-repositories/sharing-git-repositories.md
@@ -19,6 +19,8 @@ plural crypto setup-keys --name <name-for-key-pair>
 
 This will generate a new keypair and automatically register the public key with the Plural API. You should be able to see it listed [here](https://app.plural.sh/profile/keys) in our web app and the keypair will be stored in `~/.plural/identity`.
 
+If the user has not set up their plural cli yet, they'll need to run `plural login` to set up a local access token for your cli and other config files before running `plural crypto setup-keys`.
+
 ### Share the repository
 
 To share a repo, use the following command:


### PR DESCRIPTION
## Summary
There's a confusing interaction w/ users that haven't run `plural login` but are trying to register keys. This should explain.


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.