### PR TITLE
Update configuring-cloud-provider.md for GCP commands

### DIFF
--- a/pages/reference/configuring-cloud-provider.md
+++ b/pages/reference/configuring-cloud-provider.md
@@ -134,6 +134,19 @@ When deploying via GCP, you may run into a Terraform error around permissions. P
 - `owner`
 - `storage.admin`
 
+You can fix this with the following CLI commands updating `PROJECT_ID` with your GCP Project ID and `USER_EMAIL` with your GCP service account ID
+```
+> gcloud projects add-iam-policy-binding PROJECT_ID \
+    --member=user:USER_EMAIL \
+    --role=roles/owner
+```
+
+```
+> gcloud projects add-iam-policy-binding PROJECT_ID \
+    --member=user:USER_EMAIL \
+    --role=roles/storage.admin
+```
+
 Follow [these steps](https://cloud.google.com/sdk/docs/authorizing#authorize_with_a_service_account) to authorize your GCloud CLI with a new or existing Service Account.
 {% /tab %}
 


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
Minor tweaks to GCP docs to provide CLI commands to add `roles/owner` and `roles/storage.admin` roles for handling terraform resources in line with other existing copy/paste examples.


## Labels
`documentation`
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
No test plan required.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.