### PR TITLE
fix controller set up page

### DIFF
--- a/pages/how-to/set-up/controllers.md
+++ b/pages/how-to/set-up/controllers.md
@@ -60,7 +60,7 @@ spec:
 
 Notice this is expecting a `helm/runtime.yaml.liquid` file.  This would look something like:
 
-```yaml
+```yaml {% process=false %}
 plural-certmanager-webhook:
   enabled: false
 

--- a/src/generated/pages.json
+++ b/src/generated/pages.json
@@ -195,6 +195,9 @@
     "path": "/deployments/operations"
   },
   {
+    "path": "/deployments/operator/agent-api"
+  },
+  {
     "path": "/deployments/operator/api"
   },
   {


### PR DESCRIPTION
the {% endif %} yaml line was causing a bug where the rest of the page wouldn't render, setting process to false here tells the parser to just read the code block as plaintext