### PR TITLE
chore: Update auto sync configuration

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -17,7 +17,7 @@ jobs:
       run: make sync-docs
     - name: Create pull request
       id: cpr
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v7
       with:
         title: "chore: API documentation sync"
         body: |


### PR DESCRIPTION
Use default `peter-evans/create-pull-request` action behavior which is to to create a pull request that will be continually updated with new changes until it is merged or closed.

Currently it is creating new pull request each time, which produces a lot of hanging PRs if not merged on daily basis.