### PR TITLE
Add explicit docs for multi-source services

### DIFF
--- a/generated/routes.json
+++ b/generated/routes.json
@@ -9,7 +9,7 @@
   },
   "/overview/architecture": {
     "relPath": "/overview/architecture.md",
-    "lastmod": "2026-03-13T04:05:45.000Z"
+    "lastmod": "2026-03-13T12:49:45.000Z"
   },
   "/getting-started": {
     "relPath": "/getting-started/index.md",
@@ -105,11 +105,11 @@
   },
   "/api-reference/kubernetes/management-api-reference": {
     "relPath": "/api-reference/kubernetes/management-api-reference.md",
-    "lastmod": "2026-02-28T17:53:44.000Z"
+    "lastmod": "2026-05-22T20:31:36.000Z"
   },
   "/api-reference/kubernetes/agent-api-reference": {
     "relPath": "/api-reference/kubernetes/agent-api-reference.md",
-    "lastmod": "2026-02-28T17:53:44.000Z"
+    "lastmod": "2026-05-22T20:31:36.000Z"
   },
   "/api-reference/graphql": {
     "relPath": "/api-reference/graphql.md",
@@ -141,19 +141,23 @@
   },
   "/plural-features/continuous-deployment/helm-service": {
     "relPath": "/plural-features/continuous-deployment/helm-service.md",
-    "lastmod": "2025-12-30T16:00:47.000Z"
+    "lastmod": "2026-05-25T02:36:01.000Z"
+  },
+  "/plural-features/continuous-deployment/multi-source-services": {
+    "relPath": "/plural-features/continuous-deployment/multi-source-services.md",
+    "lastmod": "2026-05-25T02:36:01.000Z"
   },
   "/plural-features/continuous-deployment/resource-application-logic": {
     "relPath": "/plural-features/continuous-deployment/resource-application-logic.md",
-    "lastmod": "2026-01-16T15:34:34.000Z"
+    "lastmod": "2026-03-31T16:44:35.000Z"
   },
   "/plural-features/continuous-deployment/service-templating": {
     "relPath": "/plural-features/continuous-deployment/service-templating/index.md",
-    "lastmod": "2026-03-13T04:10:16.060Z"
+    "lastmod": "2026-05-25T02:38:46.936Z"
   },
   "/plural-features/continuous-deployment/service-templating/supporting-liquid-filters": {
     "relPath": "/plural-features/continuous-deployment/service-templating/supporting-liquid-filters.md",
-    "lastmod": "2026-03-13T04:10:16.090Z"
+    "lastmod": "2026-05-25T02:38:46.962Z"
   },
   "/plural-features/continuous-deployment/lua": {
     "relPath": "/plural-features/continuous-deployment/lua.md",
@@ -169,7 +173,7 @@
   },
   "/plural-features/continuous-deployment/pipelines": {
     "relPath": "/plural-features/continuous-deployment/pipelines.md",
-    "lastmod": "2026-03-13T04:05:45.000Z"
+    "lastmod": "2026-03-13T12:49:45.000Z"
   },
   "/plural-features/continuous-deployment/github-actions-ci": {
     "relPath": "/plural-features/continuous-deployment/github-actions-ci.md",
@@ -325,7 +329,7 @@
   },
   "/plural-features/observability/logging": {
     "relPath": "/plural-features/observability/logging.md",
-    "lastmod": "2025-12-03T21:39:43.000Z"
+    "lastmod": "2026-05-11T20:29:08.000Z"
   },
   "/plural-features/observability/cost": {
     "relPath": "/plural-features/observability/cost.md",
@@ -365,7 +369,7 @@
   },
   "/plural-features/pr-automation/ai-based-pr-automations": {
     "relPath": "/plural-features/pr-automation/ai-based-pr-automations.md",
-    "lastmod": "2026-03-13T04:05:45.000Z"
+    "lastmod": "2026-03-13T12:49:45.000Z"
   },
   "/plural-features/pr-automation/description-patterns": {
     "relPath": "/plural-features/pr-automation/description-patterns.md",
@@ -433,7 +437,7 @@
   },
   "/deployments/architecture": {
     "relPath": "/overview/architecture.md",
-    "lastmod": "2026-03-13T04:05:45.000Z"
+    "lastmod": "2026-03-13T12:49:45.000Z"
   },
   "/reference/architecture": {
     "relPath": null,
@@ -513,7 +517,7 @@
   },
   "/deployments/operator/helm-service": {
     "relPath": "/plural-features/continuous-deployment/helm-service.md",
-    "lastmod": "2025-12-30T16:00:47.000Z"
+    "lastmod": "2026-05-25T02:36:01.000Z"
   },
   "/deployments/operator/global-service": {
     "relPath": "/plural-features/continuous-deployment/global-service.md",
@@ -609,7 +613,7 @@
   },
   "/deployments/templating": {
     "relPath": "/plural-features/service-templating/index.md",
-    "lastmod": "2026-03-13T04:05:45.000Z"
+    "lastmod": "2026-03-13T12:49:45.000Z"
   },
   "/deployments/multi-tenancy": {
     "relPath": "/plural-features/projects-and-multi-tenancy/index.md",
@@ -629,10 +633,10 @@
   },
   "/management-api-reference": {
     "relPath": "/api-reference/kubernetes/management-api-reference.md",
-    "lastmod": "2026-02-28T17:53:44.000Z"
+    "lastmod": "2026-05-22T20:31:36.000Z"
   },
   "/agent-api-reference": {
     "relPath": "/api-reference/kubernetes/agent-api-reference.md",
-    "lastmod": "2026-02-28T17:53:44.000Z"
+    "lastmod": "2026-05-22T20:31:36.000Z"
   }
 }

--- a/pages/plural-features/continuous-deployment/helm-service.md
+++ b/pages/plural-features/continuous-deployment/helm-service.md
@@ -67,6 +67,8 @@ For more information, see [Dynamic Helm Configuration with Lua Scripts](lua.md).
 
 Say you want to source the helm templates from an upstream helm repository, but the values files from a Git repository.  In that case, you can define a multi-sourced service, which has both a git and helm repository defined.  It would look like so:
 
+For more advanced compositions—such as deploying an operator from Helm alongside custom resources from Git using explicit `sources` and `renderers`—see [Multi-source services](multi-source-services.md).
+
 ```yaml
 apiVersion: deployments.plural.sh/v1alpha1
 kind: GitReposiotry

--- a/pages/plural-features/continuous-deployment/multi-source-services.md
+++ b/pages/plural-features/continuous-deployment/multi-source-services.md
@@ -1,0 +1,175 @@
+---
+title: Multi-source services
+description: Combine Helm charts, Git manifests, and custom renderers in a single atomic deployment
+---
+
+Multi-source services let you assemble manifests from more than one origin—typically an upstream Helm chart plus Git-managed YAML—and ship them to the cluster as a single `ServiceDeployment`. The deployment operator renders each piece, merges the result, and applies everything in one sync.
+
+The most common use case is deploying an **operator and its custom resources together**: install the operator from a Helm chart, then apply the CRs that configure it from your infra repo, without splitting them into separate services or worrying about race conditions during rollout.
+
+## Example: datastore operator + custom resources
+
+Here's a basic example using our datastore-operator (which manages things like elasticsearch indexes and postgres databases via GitOps):
+
+```yaml
+apiVersion: deployments.plural.sh/v1alpha1
+kind: ServiceDeployment
+metadata:
+  name: datastore-operator
+  namespace: infra
+spec:
+  namespace: elastic
+  cluster: mgmt
+  sources:
+  - repositoryRef:
+      kind: GitRepository
+      name: infra
+      namespace: infra
+    git:
+      folder: services/datastores # location in git
+      ref: main
+    path: datastore-crs # location in tarball delivered to deployment-operator
+  renderers:
+  - path: datastore-crs
+    type: RAW
+  helm:
+    url: https://pluralsh.github.io/console
+    version: 0.0.46
+    chart: datastore
+```
+
+The Git folder `services/datastores` holds the operator's custom resources, for example:
+
+```yaml
+# services/datastores/elastic.yaml
+apiVersion: dbs.plural.sh/v1alpha1
+kind: ElasticsearchCredentials
+metadata:
+  name: elasticsearch
+spec:
+  url: http://elasticsearch-es-http.elastic:9200
+  username: elastic
+  passwordSecretKeyRef:
+    name: elasticsearch-es-elastic-user
+    key: elastic
+```
+
+```yaml
+# services/datastores/ilm.yaml
+apiVersion: dbs.plural.sh/v1alpha1
+kind: ElasticsearchILMPolicy
+metadata:
+  name: plrl-ilm
+spec:
+  name: plrl-ilm
+  credentialsRef:
+    name: elasticsearch
+  definition:
+    policy:
+      phases:
+        warm:
+          min_age: 5d
+          actions:
+            forcemerge:
+              max_num_segments: 1
+        delete:
+          min_age: 7d
+          actions:
+            delete: {}
+```
+
+Because both the Helm release and the CRs belong to one service, they share a revision, drift detection, and sync lifecycle.
+
+## How `sources` works
+
+Each entry in `spec.sources` fetches content from a Git repository and places it under a dedicated subdirectory in the tarball the Console delivers to the deployment operator.
+
+| Field | Role |
+| --- | --- |
+| `repositoryRef` | Reference to a `GitRepository` CR (or inline `git.url`) |
+| `git.folder` | Subdirectory within that repo to fetch |
+| `git.ref` | Branch, tag, or commit to checkout |
+| `path` | Subdirectory name inside the final tarball |
+
+The **primary source** (`spec.helm`, `spec.git`, or `spec.kustomize`) is unpacked at the tarball root. Each additional `sources` entry is merged under its own `path`. For the example above, the tarball layout looks like:
+
+```
+./                          # Helm chart files (from spec.helm)
+Chart.yaml
+templates/
+...
+datastore-crs/              # from spec.sources[0].path
+  elastic.yaml
+  ilm.yaml
+  indextemplate.yaml
+```
+
+If `path` is omitted, files from that source are placed at the tarball root alongside the primary source. When multiple sources specify the same `path`, their files are merged into that directory.
+
+This is distinct from the simpler pattern documented in [Helm-sourced services](helm-service.md#multi-source-helm), where `spec.git` provides values files for a Helm chart. The `sources` field is for **additional** Git locations beyond the primary source, each with its own destination directory.
+
+## How `renderers` works
+
+Before manifests are applied, the deployment operator renders the tarball into a flat list of Kubernetes objects. Rendering happens in two stages:
+
+1. **Default render** — The operator inspects the tarball root and auto-detects the renderer (`HELM` if it finds `Chart.yaml`, `KUSTOMIZE` if it finds `kustomization.yaml`, otherwise `RAW`). This uses the top-level `spec.helm`, `spec.kustomize`, or raw YAML settings.
+2. **Explicit renderers** — Each entry in `spec.renderers` is processed **in list order**. Each renderer runs against `tarball-root/<renderer.path>` using the specified type.
+
+Supported renderer types:
+
+| Type | Behavior |
+| --- | --- |
+| `AUTO` | Auto-detect Helm, Kustomize, or RAW at the given path |
+| `HELM` | Render a Helm chart at the path; optional per-renderer `helm` overrides for values, release name, etc. |
+| `KUSTOMIZE` | Run Kustomize at the path |
+| `RAW` | Apply YAML files directly (with optional Liquid templating) |
+
+In the datastore example, the default pass renders the Helm chart at `./`, and the explicit `RAW` renderer processes everything under `datastore-crs/`.
+
+When `spec.renderers` is non-empty, the operator **deduplicates** the combined manifest list. If the same object (group, version, kind, namespace, name) appears more than once, the copy from the **later** renderer wins. This lets an explicit renderer override resources produced by the default pass or an earlier renderer.
+
+To render only specific paths and skip the default root pass, list a renderer for each path you need—including the root with `path: .` and the appropriate type.
+
+## Controlling apply order
+
+Rendering order and apply order are separate concerns. Once all manifests are rendered and merged, the deployment operator applies them according to [Resource Application Logic](resource-application-logic.md):
+
+- **Default wave ordering** groups resources by kind (cluster-scoped first, then config, workloads, networking, and everything else).
+- **Sync waves** (`deployment.plural.sh/sync-wave`) override that default and let you enforce explicit ordering within a sync.
+
+For operator + CR deployments, you often need the operator (and its CRDs) running before custom resources are accepted by the API server. In practice:
+
+- Helm charts for operators usually install CRDs and the controller in early default waves (CRDs are cluster-scoped, wave 0).
+- If your CRs must wait for the operator webhook or controller to be ready, add a sync wave annotation to delay them:
+
+```yaml
+apiVersion: dbs.plural.sh/v1alpha1
+kind: ElasticsearchCredentials
+metadata:
+  name: elasticsearch
+  annotations:
+    deployment.plural.sh/sync-wave: "5"
+spec:
+  # ...
+```
+
+You can also use **sync hooks** (`deployment.plural.sh/sync-hook`) for pre-sync or post-sync jobs—for example, a migration that must complete before the main workload rolls out. See [Resource Application Logic](resource-application-logic.md) for sync waves, hooks, and hook delete policies.
+
+{% callout severity="info" %}
+Multi-source services make it easy to ship an operator and its CRs atomically, but Kubernetes still enforces API-level ordering. Use sync waves when the default kind-based ordering is not enough—for example, when CRs depend on a validating webhook that the operator registers after startup.
+{% /callout %}
+
+## When to use multi-source services
+
+| Scenario | Primary source | Additional `sources` |
+| --- | --- | --- |
+| Operator + CRs | `spec.helm` (upstream chart) | Git folder with CR manifests |
+| Helm chart + Kustomize overlays | `spec.helm` | Git folder with Kustomize base/overlays |
+| Multiple Git repos | `spec.git` | Additional repos at distinct `path` values |
+| Helm values from Git | `spec.git` + `spec.helm` | *(use the simpler pattern in [Helm-sourced services](helm-service.md#multi-source-helm) instead)* |
+
+## Related documentation
+
+- [Helm-sourced services](helm-service.md) — primary Helm configuration and values-from-Git pattern
+- [Git-sourced services](git-service.md) — sourcing manifests directly from Git
+- [Resource Application Logic](resource-application-logic.md) — sync waves, hooks, and apply ordering

--- a/src/routing/docs-structure.ts
+++ b/src/routing/docs-structure.ts
@@ -115,6 +115,10 @@ export const docsStructure: DocSection[] = [
           { path: 'git-service', title: 'Git-sourced services' },
           { path: 'helm-service', title: 'Helm-sourced services' },
           {
+            path: 'multi-source-services',
+            title: 'Multi-source services',
+          },
+          {
             path: 'resource-application-logic',
             title: 'Resource Application Logic',
           },


### PR DESCRIPTION
Just uses our datastore operator example, which is a good operator + cr case

<!--- Hello Plural contributor! It's great to have you on board! -->

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

Plural Flow: docs
Plural Preview: docs